### PR TITLE
fix(transfers): replace transfers map field with atomic.Pointer

### DIFF
--- a/internal/download/cleanup_test.go
+++ b/internal/download/cleanup_test.go
@@ -29,9 +29,16 @@ type fakePutioClient struct {
 	// (transfers_test.go uses these to drive the failed-retry cascade).
 	getAllTransferFilesFn func(fileID int64) ([]*putio.File, error)
 	retryTransferFn       func(transferID int64) (*putio.Transfer, error)
+	getTransfersFn        func() ([]*putio.Transfer, error)
 }
 
 func (f *fakePutioClient) GetTransfers(ctx context.Context) ([]*putio.Transfer, error) {
+	f.mu.Lock()
+	fn := f.getTransfersFn
+	f.mu.Unlock()
+	if fn != nil {
+		return fn()
+	}
 	return nil, nil
 }
 func (f *fakePutioClient) GetAllTransferFiles(ctx context.Context, fileID int64) ([]*putio.File, error) {

--- a/internal/download/transfers.go
+++ b/internal/download/transfers.go
@@ -6,21 +6,38 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/elsbrock/go-putio"
 	"github.com/elsbrock/plundrio/internal/log"
 )
 
-// TransferProcessor handles the processing of Put.io transfers
+// TransferProcessor handles the processing of Put.io transfers.
+//
+// The transfers field is a pointer to an immutable map. checkTransfers builds
+// a fresh map each tick and atomic-swaps it; readers (GetTransfers,
+// findPutioTransferByID, the process* methods) Load() the pointer and treat
+// the result as read-only. Replacing the whole map rather than mutating an
+// existing one means readers never see a partial state and need no locks.
 type TransferProcessor struct {
 	manager            *Manager
-	transfers          map[string][]*putio.Transfer // Status -> Transfers
-	processedTransfers sync.Map                     // map[int64]bool - Tracks transfers that have been processed locally
-	retryAttempts      sync.Map                     // map[int64]int - Tracks retry attempts for put.io ERROR transfers (processErroredTransfers)
-	failedRetryStates  sync.Map                     // map[int64]*localRetryState - Tracks local retry attempts for TransferLifecycleFailed transfers (processFailedTransfers)
+	transfers          atomic.Pointer[map[string][]*putio.Transfer] // Status -> Transfers (immutable once published)
+	processedTransfers sync.Map                                     // map[int64]bool - Tracks transfers that have been processed locally
+	retryAttempts      sync.Map                                     // map[int64]int - Tracks retry attempts for put.io ERROR transfers (processErroredTransfers)
+	failedRetryStates  sync.Map                                     // map[int64]*localRetryState - Tracks local retry attempts for TransferLifecycleFailed transfers (processFailedTransfers)
 	folderID           int64
 	targetDir          string
+}
+
+// loadTransfers returns the most recently published transfer snapshot, or an
+// empty map if checkTransfers hasn't run yet. Callers must treat the returned
+// map as read-only.
+func (p *TransferProcessor) loadTransfers() map[string][]*putio.Transfer {
+	if m := p.transfers.Load(); m != nil {
+		return *m
+	}
+	return map[string][]*putio.Transfer{}
 }
 
 // localRetryState tracks a single failed transfer's progress through the
@@ -57,7 +74,7 @@ const putioFallbackWait = 30 * time.Minute
 // GetTransfers returns a copy of all transfers for a given folder ID
 func (p *TransferProcessor) GetTransfers() []*putio.Transfer {
 	var allTransfers []*putio.Transfer
-	for _, transfers := range p.transfers {
+	for _, transfers := range p.loadTransfers() {
 		for _, t := range transfers {
 			if t.SaveParentID == p.folderID {
 				allTransfers = append(allTransfers, t)
@@ -69,14 +86,16 @@ func (p *TransferProcessor) GetTransfers() []*putio.Transfer {
 
 // newTransferProcessor creates a new transfer processor
 func newTransferProcessor(m *Manager) *TransferProcessor {
-	return &TransferProcessor{
+	p := &TransferProcessor{
 		manager:            m,
-		transfers:          make(map[string][]*putio.Transfer),
 		processedTransfers: sync.Map{},
 		retryAttempts:      sync.Map{},
 		folderID:           m.cfg.FolderID,
 		targetDir:          m.cfg.TargetDir,
 	}
+	empty := map[string][]*putio.Transfer{}
+	p.transfers.Store(&empty)
+	return p
 }
 
 // monitorTransfers periodically checks for completed transfers
@@ -119,10 +138,10 @@ func (p *TransferProcessor) checkTransfers() {
 		Int("api_transfers_count", len(transfers)).
 		Msg("Retrieved transfers from API")
 
-	// Reset transfer status tracking
-	p.transfers = make(map[string][]*putio.Transfer)
-
-	// Categorize transfers by status
+	// Build a fresh snapshot, then atomic-swap. Readers (GetTransfers,
+	// findPutioTransferByID) see either the previous map or this one — never
+	// a partially-built state.
+	snapshot := make(map[string][]*putio.Transfer)
 	for _, t := range transfers {
 		if t.SaveParentID != p.folderID {
 			log.Debug("transfers").
@@ -132,8 +151,9 @@ func (p *TransferProcessor) checkTransfers() {
 				Msg("Skipping transfer from different folder")
 			continue
 		}
-		p.transfers[t.Status] = append(p.transfers[t.Status], t)
+		snapshot[t.Status] = append(snapshot[t.Status], t)
 	}
+	p.transfers.Store(&snapshot)
 
 	// Log transfer summary
 	p.logTransferSummary()
@@ -149,15 +169,16 @@ func (p *TransferProcessor) checkTransfers() {
 
 // logTransferSummary logs counts of transfers in each status and detailed information for all transfers
 func (p *TransferProcessor) logTransferSummary() {
+	transfers := p.loadTransfers()
 	counts := map[string]int{
-		"IN_QUEUE":    len(p.transfers["IN_QUEUE"]),
-		"WAITING":     len(p.transfers["WAITING"]),
-		"PREPARING":   len(p.transfers["PREPARING"]),
-		"DOWNLOADING": len(p.transfers["DOWNLOADING"]),
-		"COMPLETING":  len(p.transfers["COMPLETING"]),
-		"SEEDING":     len(p.transfers["SEEDING"]),
-		"COMPLETED":   len(p.transfers["COMPLETED"]),
-		"ERROR":       len(p.transfers["ERROR"]),
+		"IN_QUEUE":    len(transfers["IN_QUEUE"]),
+		"WAITING":     len(transfers["WAITING"]),
+		"PREPARING":   len(transfers["PREPARING"]),
+		"DOWNLOADING": len(transfers["DOWNLOADING"]),
+		"COMPLETING":  len(transfers["COMPLETING"]),
+		"SEEDING":     len(transfers["SEEDING"]),
+		"COMPLETED":   len(transfers["COMPLETED"]),
+		"ERROR":       len(transfers["ERROR"]),
 	}
 
 	log.Info("transfers").
@@ -286,7 +307,8 @@ func (p *TransferProcessor) logAllTransfersDetails() {
 
 // processReadyTransfers handles completed and seeding transfers
 func (p *TransferProcessor) processReadyTransfers() {
-	readyTransfers := append(p.transfers["COMPLETED"], p.transfers["SEEDING"]...)
+	transfers := p.loadTransfers()
+	readyTransfers := append(transfers["COMPLETED"], transfers["SEEDING"]...)
 	now := time.Now()
 
 	for _, transfer := range readyTransfers {
@@ -528,7 +550,7 @@ func (p *TransferProcessor) initializeTransfer(transfer *putio.Transfer, filesTo
 func (p *TransferProcessor) processErroredTransfers() {
 	const maxRetryAttempts = 3
 
-	for _, transfer := range p.transfers["ERROR"] {
+	for _, transfer := range p.loadTransfers()["ERROR"] {
 		// Get current retry count
 		retryCountValue, exists := p.retryAttempts.Load(transfer.ID)
 		retryCount := 0
@@ -799,7 +821,7 @@ func (p *TransferProcessor) dispatchRequeue(id int64, putioTransfer *putio.Trans
 // findPutioTransferByID searches the cached put.io transfer list (populated
 // by the most recent checkTransfers run) for a given ID.
 func (p *TransferProcessor) findPutioTransferByID(id int64) *putio.Transfer {
-	for _, byStatus := range p.transfers {
+	for _, byStatus := range p.loadTransfers() {
 		for _, t := range byStatus {
 			if t.ID == id {
 				return t

--- a/internal/download/transfers_test.go
+++ b/internal/download/transfers_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -50,14 +51,15 @@ func getRetryStateForTest(t *testing.T, p *TransferProcessor, id int64) *localRe
 // findPutioTransferByID returns a known *putio.Transfer for the given ID.
 // Status "COMPLETED" by default; pass an explicit status when the test cares.
 func setPutioTransfers(p *TransferProcessor, transfers ...*putio.Transfer) {
-	p.transfers = make(map[string][]*putio.Transfer)
+	snapshot := make(map[string][]*putio.Transfer)
 	for _, t := range transfers {
 		status := t.Status
 		if status == "" {
 			status = "COMPLETED"
 		}
-		p.transfers[status] = append(p.transfers[status], t)
+		snapshot[status] = append(snapshot[status], t)
 	}
+	p.transfers.Store(&snapshot)
 }
 
 // makePutioFile returns a putio.File with a non-existent name so
@@ -683,4 +685,87 @@ func TestProcessFailedTransfersStaysFailedOnGetFilesError(t *testing.T) {
 	if ctx.GetState() != TransferLifecycleDownloading {
 		t.Errorf("state after second tick = %s, want Downloading", ctx.GetState())
 	}
+}
+
+// TestCheckTransfersAndGetTransfersRace exercises the publish/read pattern on
+// TransferProcessor.transfers under -race. checkTransfers swaps the snapshot
+// each tick; GetTransfers reads it on every *arr poll. Before the
+// atomic.Pointer switch, this was a write-vs-read on a plain map field. The
+// test only asserts no race / no panic — the contents reader sees on a given
+// call are intentionally racy in time but must always be a coherent snapshot.
+func TestCheckTransfersAndGetTransfersRace(t *testing.T) {
+	// Two snapshots that differ in length and Status keys. checkTransfers
+	// alternates between them, so any torn read would surface as a slice
+	// length mismatch or a transfer with the wrong SaveParentID — but mostly
+	// the test is here to give -race something to catch. Statuses are
+	// limited to IN_QUEUE/WAITING/DOWNLOADING/PREPARING to avoid the
+	// side-effect-heavy ready/errored paths; this test is about the
+	// publish/read pattern, not transfer processing.
+	snapshots := [][]*putio.Transfer{
+		{
+			{ID: 1, Status: "DOWNLOADING", SaveParentID: 42},
+			{ID: 2, Status: "WAITING", SaveParentID: 42},
+			{ID: 3, Status: "PREPARING", SaveParentID: 42},
+		},
+		{
+			{ID: 1, Status: "DOWNLOADING", SaveParentID: 42},
+			{ID: 4, Status: "IN_QUEUE", SaveParentID: 42},
+		},
+	}
+	var pick atomic.Int32
+	client := &fakePutioClient{
+		getTransfersFn: func() ([]*putio.Transfer, error) {
+			n := pick.Add(1) - 1
+			return snapshots[int(n)%len(snapshots)], nil
+		},
+	}
+	m := newTestManagerWithClient(client)
+	m.processor.folderID = 42
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// One writer goroutine driving checkTransfers in a tight loop.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				m.processor.checkTransfers()
+			}
+		}
+	}()
+
+	// Several reader goroutines hammering GetTransfers.
+	const readers = 8
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					ts := m.processor.GetTransfers()
+					// Coherent-snapshot check: every transfer returned must
+					// belong to folderID. A torn read could surface as a stale
+					// pointer with a wrong SaveParentID.
+					for _, tr := range ts {
+						if tr.SaveParentID != 42 {
+							t.Errorf("got transfer with SaveParentID=%d, want 42", tr.SaveParentID)
+							return
+						}
+					}
+				}
+			}
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
## Why

`TransferProcessor.transfers` is reassigned every `TransferCheckInterval` on the monitor goroutine while `Server.handleTorrentGet` reads it on every *arr poll. There's no lock and no other coordination — under load this is a write-vs-read data race. In practice it can return torn slices to *arr (missing or duplicated transfers) and on some Go versions cause a runtime panic (`fatal error: concurrent map iteration and map write`).

`go test -race` didn't catch it because no test exercised both paths concurrently.

## How

Switch the field to `atomic.Pointer[map[string][]*putio.Transfer]`. The map is fully replaced each tick — never partially mutated — so the publish/read pattern fits an atomic pointer swap perfectly. `checkTransfers` builds a fresh snapshot locally and `Store`s; readers `Load` and treat the result as immutable. No lock on the hot RPC path.

A small `loadTransfers()` helper folds the nil-check (snapshot before first tick) into one place, which keeps the readers (`GetTransfers`, `findPutioTransferByID`, `processReadyTransfers`, `processErroredTransfers`, `logTransferSummary`) straightforward.

## Notable decisions

The new test (`TestCheckTransfersAndGetTransfersRace`) limits snapshot statuses to `IN_QUEUE`/`WAITING`/`PREPARING`/`DOWNLOADING`. Including `COMPLETED`/`SEEDING`/`ERROR` would drive `processReadyTransfers` and `processErroredTransfers`, which call put.io API methods on the fake — and the fake's defaults aren't set up for those paths. The bug being tested is publish/read, not transfer processing, so trimming the surface area keeps the test focused.

(While writing the test I did notice a latent nil-deref in `processErroredTransfers` — when `client.RetryTransfer` returns `(nil, nil)` it dereferences `retried.Status`. Out of scope here; can file separately if it bites.)

Closes #1