### PR TITLE
fix(manager): drop close(m.jobs) on Stop to eliminate panic

### DIFF
--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -232,16 +232,15 @@ func (m *Manager) Stop() {
 	m.stopOnce.Do(func() {
 		// Cancel context first so in-flight API calls abort
 		m.cancel()
-		// Signal workers to stop via stopChan
+		// Signal workers and queueing path to stop via stopChan. The jobs
+		// channel is intentionally NOT closed: QueueDownload does
+		// `select { case m.jobs <- job: ... case <-m.stopChan: ... }`
+		// holding m.mu, so closing m.jobs would race with that send and
+		// can panic with "send on closed channel" (issue #2). Workers
+		// already exit on stopChan; pending buffered jobs are abandoned,
+		// which is the right behavior on shutdown — activeFiles cleanup
+		// is idempotent across restart.
 		close(m.stopChan)
-		// Close jobs channel to prevent new submissions
-		close(m.jobs)
-		// Drain any remaining jobs to prevent deadlock
-		go func() {
-			for range m.jobs {
-				// Drain jobs channel
-			}
-		}()
 	})
 
 	// Wait for all workers to finish

--- a/internal/download/manager_test.go
+++ b/internal/download/manager_test.go
@@ -1,0 +1,87 @@
+package download
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// setupForStopRace prepares a Manager for a Stop-race test without spawning
+// workers or the monitor. We set running and ctx manually so Stop's preflight
+// + stopOnce.Do path runs through; without the goroutines, workerWg/monitorWg
+// waits are no-ops.
+func setupForStopRace(t *testing.T) *Manager {
+	t.Helper()
+	m := newTestManagerWithClient(&fakePutioClient{})
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	m.mu.Lock()
+	m.running = true
+	m.mu.Unlock()
+	return m
+}
+
+// TestStopDoesNotPanicWithConcurrentQueueDownload reproduces issue #2. Before
+// the fix, Stop closed m.jobs racing with QueueDownload's `m.jobs <- job`
+// send, occasionally panicking with "send on closed channel". With close
+// removed, the same workload runs cleanly.
+//
+// Setup mirrors production: a draining goroutine plays the role of the worker
+// pool (otherwise QueueDownload blocks holding m.mu and Stop deadlocks at
+// m.mu.Lock — that path is unrelated to the panic). Many senders produce
+// constant pressure so a sender is parked in select when stopChan closes.
+func TestStopDoesNotPanicWithConcurrentQueueDownload(t *testing.T) {
+	m := setupForStopRace(t)
+
+	// Drain m.jobs in a loop so QueueDownload never permanently parks
+	// holding m.mu. Stand-in for the real worker pool.
+	drainerDone := make(chan struct{})
+	go func() {
+		defer close(drainerDone)
+		for {
+			select {
+			case <-m.stopChan:
+				return
+			case _, ok := <-m.jobs:
+				if !ok {
+					return
+				}
+			}
+		}
+	}()
+
+	const senders = 64
+	var wg sync.WaitGroup
+	wg.Add(senders)
+	for i := 0; i < senders; i++ {
+		fileID := int64(i + 1)
+		go func() {
+			defer wg.Done()
+			// A few iterations per sender to extend the race window.
+			for j := 0; j < 50; j++ {
+				m.QueueDownload(downloadJob{
+					FileID:     fileID*1000 + int64(j),
+					Name:       "file",
+					TransferID: 1,
+				})
+			}
+		}()
+	}
+
+	// Give senders a head start, then trigger Stop concurrently with the
+	// in-flight sends.
+	time.Sleep(2 * time.Millisecond)
+	m.Stop()
+
+	wg.Wait()
+	<-drainerDone
+}
+
+// TestStopMultipleTimesIsSafe asserts stopOnce still guards repeated Stop
+// calls.
+func TestStopMultipleTimesIsSafe(t *testing.T) {
+	m := setupForStopRace(t)
+	m.Stop()
+	m.Stop()
+	m.Stop()
+}


### PR DESCRIPTION
## Why

`Stop` closed both `stopChan` and `m.jobs`. `QueueDownload` selects on `m.jobs <- job` and `<-m.stopChan`; if `Stop` fires while a sender is parked in that select, both cases become ready and Go's non-deterministic select can pick the send case on a now-closed channel — `panic: send on closed channel`. The window is small but real, and it triggers on `systemctl restart plundrio` while *arr is mid-poll.

## How

`m.jobs` doesn't need to be closed for shutdown. Workers exit on `<-m.stopChan` (the existing first case in the worker's select), not on channel close. The drain goroutine that ran after `close(m.jobs)` only existed to handle the buffered-channel-close case, and disappears with the close. Pending buffered jobs are abandoned on shutdown — correct, since `activeFiles` cleanup is idempotent across restart.

## Notable decisions

The new test (`TestStopDoesNotPanicWithConcurrentQueueDownload`) needs a draining stand-in for the worker pool because `QueueDownload` holds `m.mu` across its select. Without anything draining `m.jobs`, senders park holding `m.mu` once the buffer fills, and `Stop` then deadlocks at `m.mu.Lock`. That deadlock is a pre-existing, separate issue from #2 — same bug surface, different root cause (lock held across blocking send) — and is out of scope for this PR. The drainer in the test simulates real-world conditions where workers continuously pull jobs.

Closes #2