### PR TITLE
fix(server): reject downloadDir that escapes targetDir

### DIFF
--- a/internal/server/torrent.go
+++ b/internal/server/torrent.go
@@ -17,7 +17,16 @@ import (
 
 // extractCategory returns the relative category path from downloadDir.
 // For example, if targetDir="/downloads" and downloadDir="/downloads/tv",
-// it returns "tv". Returns "" if downloadDir is empty or equals targetDir.
+// it returns "tv". Returns "" if downloadDir is empty, equals targetDir,
+// or escapes targetDir.
+//
+// Escape behavior matters for security: the returned category is joined
+// into the local write path in TransferProcessor.shouldDownloadFile and
+// queueFileDownload via filepath.Join, which normalizes "../" segments.
+// If we returned "../etc" here, files would land outside targetDir. Fail
+// closed by returning "" — that's the same as the documented "no
+// downloadDir" behavior, so files just go to the flat targetDir instead
+// of writing to an unintended location.
 func extractCategory(targetDir, downloadDir string) string {
 	if downloadDir == "" {
 		return ""
@@ -26,8 +35,19 @@ func extractCategory(targetDir, downloadDir string) string {
 	if err != nil || rel == "." {
 		return ""
 	}
-	// Clean up any trailing slashes or path oddities
-	return filepath.Clean(rel)
+	rel = filepath.Clean(rel)
+	// Reject any path that escapes targetDir. After Clean, an escaping
+	// path always starts with ".." (either bare ".." or "../..."). Pure
+	// "." was already returned above.
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		log.Warn("server").
+			Str("target_dir", targetDir).
+			Str("download_dir", downloadDir).
+			Str("rejected_rel", rel).
+			Msg("downloadDir escapes targetDir; ignoring category and writing to targetDir")
+		return ""
+	}
+	return rel
 }
 
 // findTransferByHash finds a transfer by its hash string

--- a/internal/server/torrent_test.go
+++ b/internal/server/torrent_test.go
@@ -155,6 +155,34 @@ func TestExtractCategory(t *testing.T) {
 			downloadDir: "/downloads/tv/",
 			want:        "tv",
 		},
+		// Path-traversal cases: extractCategory must reject anything that
+		// escapes targetDir, otherwise the category gets joined into the
+		// download path and filepath.Join normalizes "../" — letting a
+		// misconfigured (or malicious) *arr write outside TargetDir.
+		{
+			name:        "escape to absolute path outside",
+			targetDir:   "/downloads",
+			downloadDir: "/etc",
+			want:        "",
+		},
+		{
+			name:        "escape via dotdot in absolute path",
+			targetDir:   "/downloads",
+			downloadDir: "/downloads/../etc",
+			want:        "",
+		},
+		{
+			name:        "relative dotdot",
+			targetDir:   "/downloads",
+			downloadDir: "../foo",
+			want:        "",
+		},
+		{
+			name:        "deeper escape",
+			targetDir:   "/downloads",
+			downloadDir: "/downloads/sub/../../etc",
+			want:        "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Why

`extractCategory` used `filepath.Rel(targetDir, downloadDir)` and returned the result unchecked. If an *arr sent `downloadDir=/etc` with `targetDir=/downloads`, `Rel` returned `"../etc"`; that became the category, joined into the write path via `filepath.Join` — and `Join` normalizes `"../"` segments. So writes could land outside `targetDir`.

The delete path validates correctly (`deleteLocalData` rejects paths outside `targetDir`). The write path didn't. Asymmetric.

Threat model is single-tenant home use, but a misconfigured *arr (typo in download dir) silently writes to the wrong place rather than failing loudly — and if anyone ever exposed the Transmission RPC port without auth, this was the foothold.

## How

Detect escapes after `filepath.Clean`: an escaping path always starts with `..` (either bare `..` or `../...`). Return `""` and log a warn. Empty category means the file lands flat in `TargetDir`, which is the documented "no downloadDir" behavior — fail closed, no surprise writes.

Tests cover `/etc`, `/downloads/../etc`, `../foo`, and a deeper `/downloads/sub/../../etc` escape.

Closes #3