### PR TITLE
fix(config): read PLDR_TOKEN_FILE for systemd-credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ Configuration values are loaded in the following order, with later sources overr
 
 💡 **Security Note**: Store OAuth tokens in environment variables rather than config files or command-line arguments for better security.
 
+For systemd-managed deployments (including the bundled NixOS module), set `PLDR_TOKEN_FILE=/path/to/token` instead of `PLDR_TOKEN`. plundrio reads the file at startup and trims trailing whitespace, which lets the token live in `LoadCredential` rather than the unit's `Environment=`. If both `PLDR_TOKEN` and `PLDR_TOKEN_FILE` are set, the explicit token wins.
+
 ## 🔌 Configuring *arr Applications
 
 To add plundrio to your *arr application (Sonarr, Radarr, etc.):

--- a/cmd/plundrio/main.go
+++ b/cmd/plundrio/main.go
@@ -64,7 +64,10 @@ var runCmd = &cobra.Command{
 		// Get configuration values from viper (which checks env vars, config file, and flags)
 		targetDir := viper.GetString("target")
 		putioFolder := strings.ToLower(viper.GetString("folder"))
-		oauthToken := viper.GetString("token")
+		oauthToken, err := resolveOAuthToken(viper.GetString("token"), os.Getenv("PLDR_TOKEN_FILE"))
+		if err != nil {
+			log.Fatal("config").Err(err).Msg("Failed to read PLDR_TOKEN_FILE")
+		}
 		listenAddr := viper.GetString("listen")
 		workerCount := viper.GetInt("workers")
 		downloadStartWindow := config.DownloadStartWindowConfig{

--- a/cmd/plundrio/token.go
+++ b/cmd/plundrio/token.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// resolveOAuthToken returns the put.io OAuth token, preferring an explicit
+// `token` value (from flag, env, or config file) over a token-file path.
+//
+// PLDR_TOKEN_FILE is the systemd-credentials integration: the NixOS module
+// sets `LoadCredential=token:<path>` and exposes the credential dir via
+// `PLDR_TOKEN_FILE=%d/token`. Without this resolver, the env var was
+// advertised but ignored — plundrio started with an empty token and died
+// in Authenticate.
+//
+// Behavior:
+//   - both empty: return ""; main.go's required-values check rejects it.
+//   - explicit token only: return as-is.
+//   - tokenFile only: read the file, trim trailing whitespace.
+//   - both set: explicit wins (env layering convention).
+//   - tokenFile set but file missing/unreadable: return error so the caller
+//     fails loudly rather than silently falling back to an empty token.
+func resolveOAuthToken(explicit, tokenFile string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if tokenFile == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return "", fmt.Errorf("read token file %q: %w", tokenFile, err)
+	}
+	return strings.TrimRight(string(data), "\r\n \t"), nil
+}

--- a/cmd/plundrio/token_test.go
+++ b/cmd/plundrio/token_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTokenFile(t *testing.T, dir, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestResolveOAuthToken(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := writeTokenFile(t, dir, "from-file\n")
+
+	tests := []struct {
+		name      string
+		explicit  string
+		tokenFile string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:     "both empty",
+			want:     "",
+		},
+		{
+			name:     "explicit only",
+			explicit: "from-env",
+			want:     "from-env",
+		},
+		{
+			name:      "file only — trims trailing newline",
+			tokenFile: tokenPath,
+			want:      "from-file",
+		},
+		{
+			name:      "explicit wins over file",
+			explicit:  "from-env",
+			tokenFile: tokenPath,
+			want:      "from-env",
+		},
+		{
+			name:      "missing file returns error",
+			tokenFile: filepath.Join(dir, "does-not-exist"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveOAuthToken(tt.explicit, tt.tokenFile)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveOAuthToken(%q, %q) = %q, want %q", tt.explicit, tt.tokenFile, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveOAuthTokenStripsTrailingWhitespaceVariants(t *testing.T) {
+	cases := map[string]string{
+		"trailing LF":     "secret\n",
+		"trailing CRLF":   "secret\r\n",
+		"trailing tab":    "secret\t",
+		"trailing spaces": "secret   ",
+		"no trailing":     "secret",
+	}
+	dir := t.TempDir()
+	for name, contents := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(dir, name)
+			if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := resolveOAuthToken("", path)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != "secret" {
+				t.Errorf("got %q, want %q", got, "secret")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

The NixOS module wires the put.io token through systemd `LoadCredential` and exposes it via `PLDR_TOKEN_FILE=%d/token`, but `main.go` only ever read `PLDR_TOKEN`. plundrio started with an empty token on NixOS and died in `Authenticate` (or hit the required-values check earlier). Fork-only — upstream doesn't ship a NixOS module.

## How

Add `resolveOAuthToken(explicit, tokenFile)`:

- explicit token wins (env layering convention),
- falls back to reading the file and trimming trailing whitespace,
- file-read errors are fatal so a misconfig fails loudly rather than silently producing an empty token.

The token file is read directly via `os.Getenv("PLDR_TOKEN_FILE")` rather than going through Viper. Reason: Viper's flag-binding doesn't have a one-line story for "this var is a file pointer," and adding a `--token-file` flag would also require updating the NixOS module to keep behavior consistent. Direct env read keeps the systemd unit's existing contract.

## Notable decisions

`strings.TrimRight(data, "\r\n \t")` rather than full `TrimSpace`. A leading space in a token would be a bug to surface, not silently swallow — only trailing whitespace from the credential-file write side gets normalized.

Closes #5