### PR TITLE
ci: add -race to tests, golangci-lint, and nix build on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,4 +14,23 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go build ./...
-      - run: go test ./...
+      - run: go test -race ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix build .#plundrio

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,13 @@ nix develop
 go build ./cmd/plundrio && ./plundrio run --help
 ```
 
-**CI** (`.github/workflows/build.yml`) runs `nix build` for all four targets (native, aarch64, docker, docker-aarch64) on every push/PR.
+**CI** (`.github/workflows/build.yml`) runs three jobs on every push/PR:
+
+- `go` — `go build` and `go test -race` against the version in `go.mod`.
+- `lint` — `golangci-lint` (default linters; no `.golangci.yml` yet).
+- `nix` — `nix build .#plundrio` (native only — full multi-arch matrix runs at release time via `release.yml`, which fires `on: release: published`).
+
+`release.yml` builds all four targets (native, aarch64, docker, docker-aarch64) at release publish.
 
 **Important**: When Go dependencies change (`go.mod`/`go.sum`), the `vendorHash` in `flake.nix` (line 169) must be updated. Build the project with Nix; the error message will contain the correct hash.
 


### PR DESCRIPTION
## Why

Three pre-existing gaps in CI:

- `go test` ran without `-race`, so the regression tests added with #1 and #2 wouldn't catch their respective races on the next run.
- A broken Nix build only surfaced at release time (after the tag was already cut), because `release.yml` was the only place running `nix build` and it fires `on: release: published`.
- No lint at all. The Nix dev shell has `golangci-lint` pinned, but anyone outside `nix develop` can't run it locally because the user's host Go is older than `go.mod` requires.
- `CLAUDE.md`'s "Build & CI" section claimed CI ran the full multi-arch matrix on every push/PR. That was stale — only `release.yml` does that.

## How

`build.yml` now has three jobs:

- **go** — `go test -race ./...` instead of plain `go test`. Same checkout/setup-go.
- **lint** — `golangci-lint-action@v8` with `version: latest` and default linters. No `.golangci.yml` yet; if defaults are too noisy we pin in a follow-up.
- **nix** — `nix build .#plundrio` only (native). The aarch64 / docker / docker-aarch64 targets stay in `release.yml` — running the full matrix on every PR would burn ~3× the runtime for marginal value.

CLAUDE.md updated to describe the actual setup (three jobs on PR, full matrix on release).

## Notable decisions

`golangci-lint` runs with no project config. The PR explicitly accepts this as "let's see what the defaults flag" — issue #11 (small cleanups) already calls out a likely errcheck hit on `viper.BindPFlags`, so some lint findings are expected and will be addressed there. If lint-on-CI proves too noisy on first run, the next PR can drop a minimal `.golangci.yml`.

Closes #6