### PR TITLE
chore: small cleanups (BindPFlags error, log-level docs, module path)

### DIFF
--- a/cmd/plundrio/main.go
+++ b/cmd/plundrio/main.go
@@ -10,11 +10,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/elsbrock/plundrio/internal/api"
-	"github.com/elsbrock/plundrio/internal/config"
-	"github.com/elsbrock/plundrio/internal/download"
-	"github.com/elsbrock/plundrio/internal/log"
-	"github.com/elsbrock/plundrio/internal/server"
+	"github.com/doodla/plundrio/internal/api"
+	"github.com/doodla/plundrio/internal/config"
+	"github.com/doodla/plundrio/internal/download"
+	"github.com/doodla/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -48,7 +48,9 @@ var runCmd = &cobra.Command{
 		}
 
 		// Bind flags to Viper
-		viper.BindPFlags(cmd.Flags())
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			log.Fatal("config").Err(err).Msg("Failed to bind command flags")
+		}
 
 		// Set log level from env/config/flag (in that order)
 		logLevel := viper.GetString("log-level")
@@ -199,7 +201,7 @@ download_start_window:       # Optional local download start window
   enabled: false
   start: "23:00"
   end: "05:00"
-log_level: "info"					  # Log level (trace,debug,info,warn,error,fatal,panic,none,pretty)
+log_level: "info"					  # Log level (debug,info,warn,error,fatal,none)
 
 # Environment variables:
 # PLDR_TARGET, PLDR_FOLDER, PLDR_TOKEN, PLDR_LISTEN, PLDR_WORKERS,
@@ -305,7 +307,7 @@ func init() {
 	runCmd.Flags().StringP("token", "k", "", "Put.io OAuth token (required)")
 	runCmd.Flags().StringP("listen", "l", ":9091", "Listen address")
 	runCmd.Flags().IntP("workers", "w", 4, "Number of workers")
-	runCmd.Flags().String("log-level", "", "Log level (trace,debug,info,warn,error,fatal,none,pretty)")
+	runCmd.Flags().String("log-level", "", "Log level (debug,info,warn,error,fatal,none)")
 
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(getTokenCmd)

--- a/cmd/plundrio/main.go
+++ b/cmd/plundrio/main.go
@@ -95,7 +95,7 @@ var runCmd = &cobra.Command{
 
 		if targetDir == "" || putioFolder == "" || oauthToken == "" {
 			log.Error("config").Msg("Not all required configuration values were provided")
-			cmd.Usage()
+			_ = cmd.Usage()
 			os.Exit(1)
 		}
 
@@ -244,7 +244,7 @@ var getTokenCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal("auth").Err(err).Msg("Failed to get OOB code")
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		var codeResponse struct {
 			Code      string `json:"code"`
@@ -279,10 +279,10 @@ var getTokenCmd = &cobra.Command{
 					Status     string `json:"status"`
 				}
 				if err := json.NewDecoder(tokenResp.Body).Decode(&tokenResult); err != nil {
-					tokenResp.Body.Close()
+					_ = tokenResp.Body.Close()
 					continue
 				}
-				tokenResp.Body.Close()
+				_ = tokenResp.Body.Close()
 
 				if tokenResult.Status == "OK" && tokenResult.OAuthToken != "" {
 					log.Info("auth").

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elsbrock/plundrio
+module github.com/doodla/plundrio
 
 go 1.25.0
 

--- a/internal/download/category.go
+++ b/internal/download/category.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 const stateFileName = ".plundrio-state.json"

--- a/internal/download/cleanup_test.go
+++ b/internal/download/cleanup_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/elsbrock/go-putio"
-	"github.com/elsbrock/plundrio/internal/config"
+	"github.com/doodla/plundrio/internal/config"
 )
 
 // fakePutioClient records calls and returns canned errors. Each method

--- a/internal/download/coordinator.go
+++ b/internal/download/coordinator.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 // TransferCoordinator manages the lifecycle of transfers and their associated downloads

--- a/internal/download/coordinator_test.go
+++ b/internal/download/coordinator_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/elsbrock/plundrio/internal/config"
+	"github.com/doodla/plundrio/internal/config"
 )
 
 // newTestManager creates a minimal Manager with just enough fields

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	grab "github.com/cavaliergopher/grab/v3"
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 // downloadWorker processes download jobs from the queue

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 
 	"github.com/elsbrock/go-putio"
-	"github.com/elsbrock/plundrio/internal/config"
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/config"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 // PutioClient abstracts the put.io API methods used by the download manager.

--- a/internal/download/progress.go
+++ b/internal/download/progress.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	grab "github.com/cavaliergopher/grab/v3"
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 // monitorGrabDownloadProgress starts a goroutine to monitor and log download progress from grab

--- a/internal/download/transfers.go
+++ b/internal/download/transfers.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/elsbrock/go-putio"
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 // TransferProcessor handles the processing of Put.io transfers

--- a/internal/download/transfers.go
+++ b/internal/download/transfers.go
@@ -356,7 +356,7 @@ func (p *TransferProcessor) processTransfer(transfer *putio.Transfer) {
 
 	if len(files) == 0 {
 		err := NewNoFilesFoundError(transfer.ID)
-		p.manager.coordinator.FailTransfer(transfer.ID, err)
+		_ = p.manager.coordinator.FailTransfer(transfer.ID, err)
 		return
 	}
 
@@ -374,7 +374,7 @@ func (p *TransferProcessor) processTransfer(transfer *putio.Transfer) {
 			Str("name", transfer.Name).
 			Int64("id", transfer.ID).
 			Msg("All files already exist, completing transfer")
-		p.manager.coordinator.CompleteTransfer(transfer.ID)
+		_ = p.manager.coordinator.CompleteTransfer(transfer.ID)
 		return
 	}
 }
@@ -511,7 +511,7 @@ func (p *TransferProcessor) initializeTransfer(transfer *putio.Transfer, filesTo
 			Int64("id", transfer.ID).
 			Err(err).
 			Msg("Failed to start transfer download")
-		p.manager.coordinator.FailTransfer(transfer.ID, err)
+		_ = p.manager.coordinator.FailTransfer(transfer.ID, err)
 		return false
 	}
 

--- a/internal/download/window.go
+++ b/internal/download/window.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elsbrock/plundrio/internal/config"
+	"github.com/doodla/plundrio/internal/config"
 )
 
 // ValidateStartWindow checks whether the configured download-start window is valid.

--- a/internal/download/window_test.go
+++ b/internal/download/window_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elsbrock/plundrio/internal/config"
+	"github.com/doodla/plundrio/internal/config"
 )
 
 func TestValidateStartWindow(t *testing.T) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 // handleRPC processes transmission-rpc requests

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -33,15 +33,14 @@ func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 		Tag       interface{}     `json:"tag,omitempty"`
 	}
 
-	// Handle GET method for session-get
-	if r.Method == http.MethodGet {
+	switch r.Method {
+	case http.MethodGet:
 		req.Method = "session-get"
 		log.Debug("rpc").
 			Str("client_addr", r.RemoteAddr).
 			Str("method", "GET").
 			Msg("GET request converted to session-get")
-	} else if r.Method == http.MethodPost {
-		// Parse RPC request for POST method
+	case http.MethodPost:
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			log.Error("rpc").
 				Str("client_addr", r.RemoteAddr).
@@ -56,7 +55,7 @@ func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 			Str("method", "POST").
 			Str("rpc_method", req.Method).
 			Msg("Decoded RPC request")
-	} else {
+	default:
 		log.Error("rpc").
 			Str("client_addr", r.RemoteAddr).
 			Str("method", r.Method).

--- a/internal/server/progress.go
+++ b/internal/server/progress.go
@@ -3,7 +3,7 @@ package server
 import (
 	"time"
 
-	"github.com/elsbrock/plundrio/internal/download"
+	"github.com/doodla/plundrio/internal/download"
 )
 
 // Transmission status constants

--- a/internal/server/progress_test.go
+++ b/internal/server/progress_test.go
@@ -3,7 +3,7 @@ package server
 import (
 	"testing"
 
-	"github.com/elsbrock/plundrio/internal/download"
+	"github.com/doodla/plundrio/internal/download"
 )
 
 // newTestTransferCtx creates a TransferContext for testing with the given parameters.

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 // sendError sends an error response

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,9 +9,9 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/elsbrock/go-putio"
-	"github.com/elsbrock/plundrio/internal/config"
-	"github.com/elsbrock/plundrio/internal/download"
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/config"
+	"github.com/doodla/plundrio/internal/download"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 // PutioClient abstracts the put.io API methods used by the RPC server.

--- a/internal/server/torrent.go
+++ b/internal/server/torrent.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/elsbrock/go-putio"
-	"github.com/elsbrock/plundrio/internal/download"
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/download"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 // extractCategory returns the relative category path from downloadDir.

--- a/internal/server/utils.go
+++ b/internal/server/utils.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/elsbrock/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/log"
 )
 
 // checkDiskQuota checks disk usage and handles quota warnings

--- a/plundrio-config.yaml
+++ b/plundrio-config.yaml
@@ -10,7 +10,7 @@ download_start_window:       # Optional local download start window
   enabled: false
   start: "23:00"
   end: "05:00"
-log_level: "info"					  # Log level (trace,debug,info,warn,error,fatal,panic,none,pretty)
+log_level: "info"					  # Log level (debug,info,warn,error,fatal,none)
 
 # Environment variables:
 # PLDR_TARGET, PLDR_FOLDER, PLDR_TOKEN, PLDR_LISTEN, PLDR_WORKERS,


### PR DESCRIPTION
## Why

Three independent small things, each too small for its own PR but coherent as a single "clean up the obvious dust" pass.

## How

### 1. `viper.BindPFlags` error checked

`cmd/plundrio/main.go` had a bare `viper.BindPFlags(cmd.Flags())`. The call almost never errors but errcheck flags it once #6's `golangci-lint` job runs.

### 2. Log-level docs stripped to the supported set

The flag help and generated config advertised `trace`, `panic`, and `pretty` levels. The `log.go` switch never handled them — they fell through to `InfoLevel` silently. Implementing them was an option; removing was simpler and nothing depends on the unsupported aliases. Supported set is now what the switch actually handles: `debug, info, warn, error, fatal, none`.

### 3. Module path rename

`go.mod` was still `github.com/elsbrock/plundrio`. `go install github.com/doodla/plundrio/cmd/plundrio@latest` failed because of this — the GitHub URL doesn't determine the import path, the module path does. Renamed via `go mod edit -module github.com/doodla/plundrio` and swept all internal imports. The third-party `github.com/elsbrock/go-putio` import is the put.io API library and is intentionally unchanged.

## Notable decisions

README's `go install`, Nix-flake URL, and Docker-image references still point at `elsbrock/plundrio` — out of scope for this cleanup, but worth a follow-up if we want the README to reflect the fork's URLs throughout.

Closes #11