### PR TITLE
fix(logs): suppress repetitive transfer-summary + RPC marshal noise

### DIFF
--- a/internal/download/transfers.go
+++ b/internal/download/transfers.go
@@ -21,6 +21,11 @@ type TransferProcessor struct {
 	failedRetryStates  sync.Map                     // map[int64]*localRetryState - Tracks local retry attempts for TransferLifecycleFailed transfers (processFailedTransfers)
 	folderID           int64
 	targetDir          string
+
+	// lastSummaryCounts caches the last status-count map logged by
+	// logTransferSummary so subsequent ticks with identical counts can
+	// skip the Info log. Single-writer (monitor goroutine), no lock needed.
+	lastSummaryCounts map[string]int
 }
 
 // localRetryState tracks a single failed transfer's progress through the
@@ -147,7 +152,11 @@ func (p *TransferProcessor) checkTransfers() {
 	p.finalizeCompletedTransfers()
 }
 
-// logTransferSummary logs counts of transfers in each status and detailed information for all transfers
+// logTransferSummary logs counts of transfers in each status. Info-level logs
+// only fire when counts changed since the previous tick; an idle queue would
+// otherwise flood operational logs with identical lines every
+// TransferCheckInterval. The same counts always fire at Debug for trace-level
+// visibility, plus the per-transfer detail dump.
 func (p *TransferProcessor) logTransferSummary() {
 	counts := map[string]int{
 		"IN_QUEUE":    len(p.transfers["IN_QUEUE"]),
@@ -160,7 +169,12 @@ func (p *TransferProcessor) logTransferSummary() {
 		"ERROR":       len(p.transfers["ERROR"]),
 	}
 
-	log.Info("transfers").
+	event := log.Debug("transfers")
+	if !sameCounts(p.lastSummaryCounts, counts) {
+		event = log.Info("transfers")
+		p.lastSummaryCounts = counts
+	}
+	event.
 		Int("queued", counts["IN_QUEUE"]).
 		Int("waiting", counts["WAITING"]).
 		Int("preparing", counts["PREPARING"]).
@@ -173,6 +187,19 @@ func (p *TransferProcessor) logTransferSummary() {
 
 	// Log detailed information for all transfers
 	p.logAllTransfersDetails()
+}
+
+// sameCounts compares two status-count maps for equality.
+func sameCounts(a, b map[string]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // logAllTransfersDetails logs detailed information for all transfers

--- a/internal/server/torrent.go
+++ b/internal/server/torrent.go
@@ -240,37 +240,21 @@ func (s *Server) handleTorrentGet(_ context.Context, args json.RawMessage) (inte
 		}
 
 		torrents = append(torrents, torrentInfo)
-
-		// Log each torrent being added to the response
-		log.Debug("rpc").
-			Str("operation", "torrent-get").
-			Int64("id", t.ID).
-			Str("hash", t.Hash).
-			Str("name", t.Name).
-			Str("status", t.Status).
-			Int("size", t.Size).
-			Float64("percent_done", percentDone).
-			Msg("Added torrent to response")
 	}
 
-	// Log the final count of torrents in the response
+	// Per-torrent details already log via "Calculated progress" above and
+	// the marshaled-response dump on every poll was a debug-mode flood
+	// (three *arrs at 2-5s intervals). One summary line is enough — anyone
+	// who needs the full response can reconstruct it from the per-torrent
+	// fields.
 	log.Debug("rpc").
 		Str("operation", "torrent-get").
 		Int("torrents_count", len(torrents)).
 		Msg("Returning torrents")
 
-	result := map[string]interface{}{
+	return map[string]interface{}{
 		"torrents": torrents,
-	}
-
-	// Log the final response structure
-	resultBytes, _ := json.Marshal(result)
-	log.Debug("rpc").
-		Str("operation", "torrent-get").
-		Str("result", string(resultBytes)).
-		Msg("Final result structure")
-
-	return result, nil
+	}, nil
 }
 
 // handleTorrentRemove processes torrent-remove requests


### PR DESCRIPTION
## Why

Two unnecessary log floods at typical operating volume.

`logTransferSummary` ran every 30s at Info regardless of whether anything changed. On a steady-state queue with N transfers, that's two log lines per 30s plus N Debug lines from `logAllTransfersDetails`. Fine when something's happening; pure noise when nothing is.

`handleTorrentGet` Debug-marshaled the full RPC response on every call, plus a per-torrent `"Added torrent to response"` Debug line. With three *arrs polling every 2-5s, the moment anyone enables Debug to investigate something, they drown in this.

Neither broke anything. Both made operational debugging harder.

## How

**Summary:** cache `lastSummaryCounts` on `TransferProcessor`; emit at Info only when counts differ from the previous tick, and at Debug otherwise (so trace-level visibility is preserved). Single-writer (monitor goroutine), no lock needed.

**RPC response:** drop the full-response marshal entirely — it's reconstructible from the per-torrent fields if anyone really needs it. Drop the per-torrent log too; `"Calculated progress"` higher in the same function already logs id+name+status+percent_done.

No behavior change beyond log volume.

Closes #8