### PR TITLE
feat(ui): make dashboard mobile-friendly

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="dark light" />
     <title>plundrio</title>
     <script>

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -1474,10 +1474,37 @@ footer {
 }
 @media (max-width: 560px) {
   main {
-    padding: 18px 14px 70px;
+    /* extra bottom padding clears the fixed nav tab bar + iOS home indicator */
+    padding: 18px 14px calc(72px + env(safe-area-inset-bottom));
   }
+  .rail {
+    padding: 0 14px;
+    gap: 10px;
+  }
+  /* Section nav becomes a fixed bottom tab bar (no room in the top rail). */
   .rail nav {
-    display: none;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 40;
+    margin-left: 0;
+    gap: 0;
+    background: color-mix(in srgb, var(--surf-0) 92%, transparent);
+    backdrop-filter: blur(14px);
+    border-top: 1px solid var(--hair-2);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .rail nav button {
+    flex: 1;
+    height: 54px;
+    padding: 0;
+    border-radius: 0;
+    font-size: 11px;
+  }
+  .rail nav button.on {
+    background: var(--surf-2);
+    box-shadow: inset 0 2px 0 var(--local);
   }
   .clock {
     display: none;
@@ -1485,8 +1512,25 @@ footer {
   .palpick button span.txt {
     display: none;
   }
+  /* roomier tap targets for the theme/palette controls */
+  .toggle,
+  .toggle button,
+  .palpick,
+  .palpick button {
+    height: 38px;
+  }
+  .bay {
+    padding: 20px 16px 18px;
+  }
+  .flowgauge {
+    width: min(320px, 76vw);
+    height: auto;
+    aspect-ratio: 1;
+  }
   .cluster {
     grid-template-columns: 1fr;
+    padding: 16px;
+    gap: 12px;
   }
   .ln {
     grid-template-columns: 5px 64px 110px 1fr;
@@ -1496,6 +1540,8 @@ footer {
   }
   .tr {
     grid-template-columns: 52px 1fr;
+    gap: 12px;
+    padding: 12px 14px;
   }
   .tr .trMeta {
     display: none;

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -1480,6 +1480,20 @@ footer {
   .rail {
     padding: 0 14px;
     gap: 10px;
+    /* MUST stay none on mobile: a backdrop-filter ancestor would become the
+       containing block for the fixed bottom nav below, pinning it to the rail
+       instead of the viewport. */
+    backdrop-filter: none;
+  }
+  /* Trim the top rail so brand + controls fit one line on a ~320px phone. */
+  .brand .v {
+    display: none;
+  }
+  /* Collapse the connection pill to its status dot (color still conveys state). */
+  .live {
+    gap: 0;
+    padding: 7px;
+    font-size: 0;
   }
   /* Section nav becomes a fixed bottom tab bar (no room in the top rail). */
   .rail nav {
@@ -1518,6 +1532,9 @@ footer {
   .palpick,
   .palpick button {
     height: 38px;
+  }
+  .palpick button {
+    padding: 0 8px;
   }
   .bay {
     padding: 20px 16px 18px;


### PR DESCRIPTION
The dashboard was designed desktop-first: its only mobile breakpoint
mostly hid elements rather than reflowing them, and at <=560px the
section nav was hidden entirely, leaving phone users no way to switch
between Deck/Account/Logs/Settings.

- Turn the section nav into a fixed bottom tab bar on mobile, reusing
  the existing semantic <nav> (active state already tracks the route).
- Reserve space below content for the bar and the iOS home indicator
  via env(safe-area-inset-bottom); add viewport-fit=cover so insets
  resolve on notched phones.
- Reflow/scale the top rail, master bay, flow gauge, account cluster,
  and fleet rows on narrow screens; enlarge theme/palette tap targets.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016FHqopyPDz4jQKR56t9vpb