### PR TITLE
feat(api): retry put.io API calls on HTTP 429 with backoff + jitter

### DIFF
--- a/cmd/plundrio/main.go
+++ b/cmd/plundrio/main.go
@@ -43,6 +43,7 @@ var flagViperBindings = map[string]string{
 	"transfer-check-interval": "transfer_check_interval",
 	"stall-timeout":           "stall_timeout",
 	"stall-max-retries":       "stall_max_retries",
+	"min-free-space":          "min_free_space",
 	"log-level":               "log_level",
 	"dashboard":               "dashboard",
 	"dashboard-addr":          "dashboard_addr",
@@ -208,6 +209,7 @@ var runCmd = &cobra.Command{
 			Dur("post_complete_retention", cfg.PostCompleteRetention).
 			Dur("stall_timeout", cfg.StallTimeout).
 			Int("stall_max_retries", cfg.StallMaxRetries).
+			Str("min_free_space", cfg.MinFreeSpace).
 			Bool("download_start_window_enabled", cfg.DownloadStartWindow.Enabled).
 			Str("download_start_window_start", cfg.DownloadStartWindow.Start).
 			Str("download_start_window_end", cfg.DownloadStartWindow.End).
@@ -251,6 +253,13 @@ var runCmd = &cobra.Command{
 			log.Fatal("config").
 				Dur("interval", cfg.TransferCheckInterval).
 				Msg("transfer_check_interval below 5s is not allowed outside demo mode")
+		}
+
+		// Validate the free-space floor up front so a typo ("10 PB", "abc")
+		// fails fast at startup rather than silently disabling the check deep in
+		// server.New.
+		if _, err := config.ParseByteSize(cfg.MinFreeSpace); err != nil {
+			log.Fatal("config").Err(err).Msg("Invalid min_free_space value")
 		}
 
 		// Initialize the put.io client. Demo mode swaps in the in-process fake
@@ -387,6 +396,8 @@ post_complete_retention: 24h # Grace before DeleteTransfer on put.io after local
 stall_timeout: 1h            # No-progress window before a put.io transfer is
                              # treated as stalled (then retried, then deleted).
 stall_max_retries: 1         # Stall retries before deleting (0 = delete on first stall).
+min_free_space: ""           # Opt-in floor on put.io free space (e.g. "20GB",
+                             # "10GiB"); reject torrent-add below it. Empty disables.
 download_start_window:       # Optional local download start window
   enabled: false
   start: "23:00"
@@ -396,6 +407,7 @@ log_level: "info"					  # Log level (debug,info,warn,error,fatal,none)
 # Environment variables:
 # PLDR_TARGET, PLDR_FOLDER, PLDR_TOKEN, PLDR_LISTEN, PLDR_WORKERS,
 # PLDR_POST_COMPLETE_RETENTION, PLDR_STALL_TIMEOUT, PLDR_STALL_MAX_RETRIES,
+# PLDR_MIN_FREE_SPACE,
 # PLDR_DOWNLOAD_START_WINDOW_ENABLED, PLDR_DOWNLOAD_START_WINDOW_START,
 # PLDR_DOWNLOAD_START_WINDOW_END, PLDR_LOG_LEVEL
 `
@@ -505,6 +517,7 @@ func registerRunFlags(cmd *cobra.Command) {
 	cmd.Flags().Duration("transfer-check-interval", 0, "How often to poll put.io for transfer state. 0 = default (30s). Values below 5s are rejected outside demo mode to avoid hammering the put.io API (risks HTTP 429 rate limiting).")
 	cmd.Flags().Duration("stall-timeout", time.Hour, "How long a put.io transfer may sit in a non-terminal status (queued/preparing/downloading) with no progress before it is treated as stalled and retried, then deleted. A no-seeder torrent never reaches ERROR on put.io, so without this *arr waits forever. Keep generous — put.io legitimately queues for minutes.")
 	cmd.Flags().Int("stall-max-retries", 1, "How many times a stalled put.io transfer is retried (RetryTransfer) before being deleted. 0 = delete on first stall.")
+	cmd.Flags().String("min-free-space", "", "Opt-in floor on put.io free space below which torrent-add is rejected so *arr tries another release. Human-readable (e.g. \"20GB\", \"10GiB\"); empty disables. The check fails open: a put.io account-info error lets the add proceed.")
 	cmd.Flags().String("log-level", "", "Log level (debug,info,warn,error,fatal,none)")
 	cmd.Flags().Bool("dashboard", false, "Enable the web dashboard (default off). Also via PLDR_DASHBOARD=true.")
 	cmd.Flags().String("dashboard-addr", ":9092", "Address the web dashboard binds when enabled. Also via PLDR_DASHBOARD_ADDR.")

--- a/cmd/plundrio/main.go
+++ b/cmd/plundrio/main.go
@@ -168,6 +168,33 @@ type putioClient interface {
 	server.PutioClient
 }
 
+// validateRunConfig performs the pure (non-filesystem) validation of run-time
+// config and returns the first problem found. Extracted from runCmd's Run so it
+// is unit-testable without tripping log.Fatal / os.Exit; runCmd wraps the
+// returned error in a log.Fatal.
+func validateRunConfig(cfg *config.Config, demoMode bool) error {
+	if err := download.ValidateStartWindow(cfg.DownloadStartWindow); err != nil {
+		return fmt.Errorf("invalid download start window configuration: %w", err)
+	}
+
+	// Guard against an operator setting an aggressive prod poll that would
+	// hammer the put.io API and risk HTTP 429 rate limiting. Demo mode is
+	// exempt (it intentionally sets a 1s poll). 0 means "use the 30s package
+	// default", so only a positive sub-5s value is rejected.
+	if !demoMode && cfg.TransferCheckInterval > 0 && cfg.TransferCheckInterval < 5*time.Second {
+		return fmt.Errorf("transfer_check_interval %s below 5s is not allowed outside demo mode", cfg.TransferCheckInterval)
+	}
+
+	// Validate the free-space floor up front so a typo ("10 PB", "abc") fails
+	// fast at startup rather than silently disabling the check deep in
+	// server.New.
+	if _, err := config.ParseByteSize(cfg.MinFreeSpace); err != nil {
+		return fmt.Errorf("invalid min_free_space value: %w", err)
+	}
+
+	return nil
+}
+
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run the download manager",
@@ -241,25 +268,8 @@ var runCmd = &cobra.Command{
 			log.Fatal("config").Str("dir", cfg.TargetDir).Msg("Target path is not a directory")
 		}
 
-		if err := download.ValidateStartWindow(cfg.DownloadStartWindow); err != nil {
-			log.Fatal("config").Err(err).Msg("Invalid download start window configuration")
-		}
-
-		// Guard against an operator setting an aggressive prod poll that would
-		// hammer the put.io API and risk HTTP 429 rate limiting. Demo mode is
-		// exempt (it intentionally sets a 1s poll below). 0 means "use the 30s
-		// package default", so only a positive sub-5s value is rejected.
-		if !demoMode && cfg.TransferCheckInterval > 0 && cfg.TransferCheckInterval < 5*time.Second {
-			log.Fatal("config").
-				Dur("interval", cfg.TransferCheckInterval).
-				Msg("transfer_check_interval below 5s is not allowed outside demo mode")
-		}
-
-		// Validate the free-space floor up front so a typo ("10 PB", "abc")
-		// fails fast at startup rather than silently disabling the check deep in
-		// server.New.
-		if _, err := config.ParseByteSize(cfg.MinFreeSpace); err != nil {
-			log.Fatal("config").Err(err).Msg("Invalid min_free_space value")
+		if err := validateRunConfig(cfg, demoMode); err != nil {
+			log.Fatal("config").Err(err).Msg("Invalid configuration")
 		}
 
 		// Initialize the put.io client. Demo mode swaps in the in-process fake

--- a/cmd/plundrio/main.go
+++ b/cmd/plundrio/main.go
@@ -40,6 +40,7 @@ var flagViperBindings = map[string]string{
 	"listen":                  "listen",
 	"workers":                 "workers",
 	"post-complete-retention": "post_complete_retention",
+	"transfer-check-interval": "transfer_check_interval",
 	"log-level":               "log_level",
 	"dashboard":               "dashboard",
 	"dashboard-addr":          "dashboard_addr",
@@ -236,6 +237,16 @@ var runCmd = &cobra.Command{
 
 		if err := download.ValidateStartWindow(cfg.DownloadStartWindow); err != nil {
 			log.Fatal("config").Err(err).Msg("Invalid download start window configuration")
+		}
+
+		// Guard against an operator setting an aggressive prod poll that would
+		// hammer the put.io API and risk HTTP 429 rate limiting. Demo mode is
+		// exempt (it intentionally sets a 1s poll below). 0 means "use the 30s
+		// package default", so only a positive sub-5s value is rejected.
+		if !demoMode && cfg.TransferCheckInterval > 0 && cfg.TransferCheckInterval < 5*time.Second {
+			log.Fatal("config").
+				Dur("interval", cfg.TransferCheckInterval).
+				Msg("transfer_check_interval below 5s is not allowed outside demo mode")
 		}
 
 		// Initialize the put.io client. Demo mode swaps in the in-process fake
@@ -484,6 +495,7 @@ func registerRunFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("listen", "l", ":9091", "Listen address")
 	cmd.Flags().IntP("workers", "w", 4, "Number of workers")
 	cmd.Flags().Duration("post-complete-retention", 24*time.Hour, "Grace period after local download completes before unilaterally calling DeleteTransfer on put.io. The transfer stays visible to the *arr client as Seeding/100% during this window so it has time to issue torrent-remove. Set to 0 to disable (rely on torrent-remove only — risk: put.io quota leak if RemoveCompletedDownloads=false on the client side).")
+	cmd.Flags().Duration("transfer-check-interval", 0, "How often to poll put.io for transfer state. 0 = default (30s). Values below 5s are rejected outside demo mode to avoid hammering the put.io API (risks HTTP 429 rate limiting).")
 	cmd.Flags().String("log-level", "", "Log level (debug,info,warn,error,fatal,none)")
 	cmd.Flags().Bool("dashboard", false, "Enable the web dashboard (default off). Also via PLDR_DASHBOARD=true.")
 	cmd.Flags().String("dashboard-addr", ":9092", "Address the web dashboard binds when enabled. Also via PLDR_DASHBOARD_ADDR.")

--- a/cmd/plundrio/main.go
+++ b/cmd/plundrio/main.go
@@ -41,6 +41,8 @@ var flagViperBindings = map[string]string{
 	"workers":                 "workers",
 	"post-complete-retention": "post_complete_retention",
 	"transfer-check-interval": "transfer_check_interval",
+	"stall-timeout":           "stall_timeout",
+	"stall-max-retries":       "stall_max_retries",
 	"log-level":               "log_level",
 	"dashboard":               "dashboard",
 	"dashboard-addr":          "dashboard_addr",
@@ -204,6 +206,8 @@ var runCmd = &cobra.Command{
 			Str("listen_addr", cfg.ListenAddr).
 			Int("workers", cfg.WorkerCount).
 			Dur("post_complete_retention", cfg.PostCompleteRetention).
+			Dur("stall_timeout", cfg.StallTimeout).
+			Int("stall_max_retries", cfg.StallMaxRetries).
 			Bool("download_start_window_enabled", cfg.DownloadStartWindow.Enabled).
 			Str("download_start_window_start", cfg.DownloadStartWindow.Start).
 			Str("download_start_window_end", cfg.DownloadStartWindow.End).
@@ -380,6 +384,9 @@ workers: 4									# Number of download workers
 post_complete_retention: 24h # Grace before DeleteTransfer on put.io after local
                              # download completes (window for *arr's torrent-remove);
                              # 0 disables — rely on the client to remove.
+stall_timeout: 1h            # No-progress window before a put.io transfer is
+                             # treated as stalled (then retried, then deleted).
+stall_max_retries: 1         # Stall retries before deleting (0 = delete on first stall).
 download_start_window:       # Optional local download start window
   enabled: false
   start: "23:00"
@@ -388,7 +395,7 @@ log_level: "info"					  # Log level (debug,info,warn,error,fatal,none)
 
 # Environment variables:
 # PLDR_TARGET, PLDR_FOLDER, PLDR_TOKEN, PLDR_LISTEN, PLDR_WORKERS,
-# PLDR_POST_COMPLETE_RETENTION,
+# PLDR_POST_COMPLETE_RETENTION, PLDR_STALL_TIMEOUT, PLDR_STALL_MAX_RETRIES,
 # PLDR_DOWNLOAD_START_WINDOW_ENABLED, PLDR_DOWNLOAD_START_WINDOW_START,
 # PLDR_DOWNLOAD_START_WINDOW_END, PLDR_LOG_LEVEL
 `
@@ -496,6 +503,8 @@ func registerRunFlags(cmd *cobra.Command) {
 	cmd.Flags().IntP("workers", "w", 4, "Number of workers")
 	cmd.Flags().Duration("post-complete-retention", 24*time.Hour, "Grace period after local download completes before unilaterally calling DeleteTransfer on put.io. The transfer stays visible to the *arr client as Seeding/100% during this window so it has time to issue torrent-remove. Set to 0 to disable (rely on torrent-remove only — risk: put.io quota leak if RemoveCompletedDownloads=false on the client side).")
 	cmd.Flags().Duration("transfer-check-interval", 0, "How often to poll put.io for transfer state. 0 = default (30s). Values below 5s are rejected outside demo mode to avoid hammering the put.io API (risks HTTP 429 rate limiting).")
+	cmd.Flags().Duration("stall-timeout", time.Hour, "How long a put.io transfer may sit in a non-terminal status (queued/preparing/downloading) with no progress before it is treated as stalled and retried, then deleted. A no-seeder torrent never reaches ERROR on put.io, so without this *arr waits forever. Keep generous — put.io legitimately queues for minutes.")
+	cmd.Flags().Int("stall-max-retries", 1, "How many times a stalled put.io transfer is retried (RetryTransfer) before being deleted. 0 = delete on first stall.")
 	cmd.Flags().String("log-level", "", "Log level (debug,info,warn,error,fatal,none)")
 	cmd.Flags().Bool("dashboard", false, "Enable the web dashboard (default off). Also via PLDR_DASHBOARD=true.")
 	cmd.Flags().String("dashboard-addr", ":9092", "Address the web dashboard binds when enabled. Also via PLDR_DASHBOARD_ADDR.")

--- a/cmd/plundrio/validate_test.go
+++ b/cmd/plundrio/validate_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/doodla/plundrio/internal/config"
+)
+
+func TestValidateRunConfig(t *testing.T) {
+	base := func() *config.Config { return &config.Config{} }
+
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		demoMode bool
+		wantErr  bool
+	}{
+		{"empty defaults", base(), false, false},
+		{"zero interval allowed", &config.Config{TransferCheckInterval: 0}, false, false},
+		{"5s interval allowed", &config.Config{TransferCheckInterval: 5 * time.Second}, false, false},
+		{"sub-5s interval rejected outside demo", &config.Config{TransferCheckInterval: time.Second}, false, true},
+		{"sub-5s interval allowed in demo", &config.Config{TransferCheckInterval: time.Second}, true, false},
+		{"valid min_free_space", &config.Config{MinFreeSpace: "20GB"}, false, false},
+		{"empty min_free_space allowed", &config.Config{MinFreeSpace: ""}, false, false},
+		{"bad min_free_space rejected", &config.Config{MinFreeSpace: "10 PB"}, false, true},
+		{
+			"bad start window rejected",
+			&config.Config{DownloadStartWindow: config.DownloadStartWindowConfig{Enabled: true, Start: "99:99", End: "05:00"}},
+			false,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRunConfig(tt.cfg, tt.demoMode)
+			if tt.wantErr && err == nil {
+				t.Errorf("validateRunConfig() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validateRunConfig() = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/doodla/go-putio"
 	"golang.org/x/oauth2"
@@ -23,6 +24,12 @@ type TransferFile struct {
 // Client wraps the official Put.io client
 type Client struct {
 	client *putio.Client
+
+	// sleeper backs the rate-limit retry wait (see withRateLimitRetry). It is a
+	// seam: production uses time.After; tests override it to make backoff
+	// near-instant. Mirrors the clock-injection convention used elsewhere
+	// (e.g. download.processFailedTransfersAt).
+	sleeper func(time.Duration) <-chan time.Time
 }
 
 // NewClient creates a new Put.io API client
@@ -31,13 +38,19 @@ func NewClient(oauthToken string) *Client {
 	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
 
 	return &Client{
-		client: putio.NewClient(oauthClient),
+		client:  putio.NewClient(oauthClient),
+		sleeper: time.After,
 	}
 }
 
 // Authenticate verifies the OAuth token by fetching account info
 func (c *Client) Authenticate(ctx context.Context) error {
-	account, err := c.client.Account.Info(ctx)
+	var account putio.AccountInfo
+	err := c.withRateLimitRetry(ctx, "account.info", func() error {
+		var e error
+		account, e = c.client.Account.Info(ctx)
+		return e
+	})
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
@@ -52,7 +65,12 @@ func (c *Client) Authenticate(ctx context.Context) error {
 
 // GetAccountInfo returns the Put.io account information
 func (c *Client) GetAccountInfo(ctx context.Context) (*putio.AccountInfo, error) {
-	account, err := c.client.Account.Info(ctx)
+	var account putio.AccountInfo
+	err := c.withRateLimitRetry(ctx, "account.info", func() error {
+		var e error
+		account, e = c.client.Account.Info(ctx)
+		return e
+	})
 	if err != nil {
 		return nil, fmt.Errorf("get account info: %w", err)
 	}
@@ -62,7 +80,12 @@ func (c *Client) GetAccountInfo(ctx context.Context) (*putio.AccountInfo, error)
 // EnsureFolder creates a folder if it doesn't exist or returns the ID if it does
 func (c *Client) EnsureFolder(ctx context.Context, name string) (int64, error) {
 	// List files at root to find folder
-	files, _, err := c.client.Files.List(ctx, 0)
+	var files []putio.File
+	err := c.withRateLimitRetry(ctx, "files.list", func() error {
+		var e error
+		files, _, e = c.client.Files.List(ctx, 0)
+		return e
+	})
 	if err != nil {
 		return 0, fmt.Errorf("ensure folder: %w", err)
 	}
@@ -75,7 +98,12 @@ func (c *Client) EnsureFolder(ctx context.Context, name string) (int64, error) {
 	}
 
 	// Create folder if it doesn't exist
-	folder, err := c.client.Files.CreateFolder(ctx, name, 0)
+	var folder putio.File
+	err = c.withRateLimitRetry(ctx, "files.create-folder", func() error {
+		var e error
+		folder, e = c.client.Files.CreateFolder(ctx, name, 0)
+		return e
+	})
 	if err != nil {
 		return 0, fmt.Errorf("ensure folder: %w", err)
 	}
@@ -85,7 +113,12 @@ func (c *Client) EnsureFolder(ctx context.Context, name string) (int64, error) {
 
 // AddTransfer adds a new transfer (torrent) to Put.io and returns its hash.
 func (c *Client) AddTransfer(ctx context.Context, magnetLink string, folderID int64) (string, error) {
-	transfer, err := c.client.Transfers.Add(ctx, magnetLink, folderID, "")
+	var transfer putio.Transfer
+	err := c.withRateLimitRetry(ctx, "transfers.add", func() error {
+		var e error
+		transfer, e = c.client.Transfers.Add(ctx, magnetLink, folderID, "")
+		return e
+	})
 	if err != nil {
 		return "", fmt.Errorf("add transfer: %w", err)
 	}
@@ -99,7 +132,12 @@ func (c *Client) AddTransfer(ctx context.Context, magnetLink string, folderID in
 
 // GetTransfers returns the list of current transfers
 func (c *Client) GetTransfers(ctx context.Context) ([]*putio.Transfer, error) {
-	transfers, err := c.client.Transfers.List(ctx)
+	var transfers []putio.Transfer
+	err := c.withRateLimitRetry(ctx, "transfers.list", func() error {
+		var e error
+		transfers, e = c.client.Transfers.List(ctx)
+		return e
+	})
 	if err != nil {
 		return nil, fmt.Errorf("get transfers: %w", err)
 	}
@@ -114,7 +152,12 @@ func (c *Client) GetTransfers(ctx context.Context) ([]*putio.Transfer, error) {
 
 // GetDownloadURL gets the download URL for a file
 func (c *Client) GetDownloadURL(ctx context.Context, fileID int64) (string, error) {
-	url, err := c.client.Files.URL(ctx, fileID, false)
+	var url string
+	err := c.withRateLimitRetry(ctx, "files.url", func() error {
+		var e error
+		url, e = c.client.Files.URL(ctx, fileID, false)
+		return e
+	})
 	if err != nil {
 		return "", fmt.Errorf("get download URL: %w", err)
 	}
@@ -123,7 +166,10 @@ func (c *Client) GetDownloadURL(ctx context.Context, fileID int64) (string, erro
 
 // DeleteTransfer removes a transfer from Put.io
 func (c *Client) DeleteTransfer(ctx context.Context, transferID int64) error {
-	if err := c.client.Transfers.Cancel(ctx, transferID); err != nil {
+	err := c.withRateLimitRetry(ctx, "transfers.cancel", func() error {
+		return c.client.Transfers.Cancel(ctx, transferID)
+	})
+	if err != nil {
 		return fmt.Errorf("cancel transfer: %w", err)
 	}
 	return nil
@@ -131,7 +177,12 @@ func (c *Client) DeleteTransfer(ctx context.Context, transferID int64) error {
 
 // GetFiles gets the contents of a folder
 func (c *Client) GetFiles(ctx context.Context, folderID int64) ([]*putio.File, error) {
-	files, _, err := c.client.Files.List(ctx, folderID)
+	var files []putio.File
+	err := c.withRateLimitRetry(ctx, "files.list", func() error {
+		var e error
+		files, _, e = c.client.Files.List(ctx, folderID)
+		return e
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list files: %w", err)
 	}
@@ -146,7 +197,10 @@ func (c *Client) GetFiles(ctx context.Context, folderID int64) ([]*putio.File, e
 
 // DeleteFile removes a file from Put.io
 func (c *Client) DeleteFile(ctx context.Context, fileID int64) error {
-	if err := c.client.Files.Delete(ctx, fileID); err != nil {
+	err := c.withRateLimitRetry(ctx, "files.delete", func() error {
+		return c.client.Files.Delete(ctx, fileID)
+	})
+	if err != nil {
 		return fmt.Errorf("delete file: %w", err)
 	}
 	return nil
@@ -155,8 +209,15 @@ func (c *Client) DeleteFile(ctx context.Context, fileID int64) error {
 // UploadFile uploads a torrent file to Put.io and returns the transfer hash
 // if one was created.
 func (c *Client) UploadFile(ctx context.Context, data []byte, filename string, folderID int64) (string, error) {
-	reader := bytes.NewReader(data)
-	upload, err := c.client.Files.Upload(ctx, reader, filename, folderID)
+	var upload putio.Upload
+	err := c.withRateLimitRetry(ctx, "files.upload", func() error {
+		// Recreate the reader on each attempt: a retried upload must restart
+		// from the beginning of the data, not from a consumed reader.
+		reader := bytes.NewReader(data)
+		var e error
+		upload, e = c.client.Files.Upload(ctx, reader, filename, folderID)
+		return e
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to upload file: %w", err)
 	}
@@ -173,7 +234,15 @@ func (c *Client) UploadFile(ctx context.Context, data []byte, filename string, f
 // leaf at the top level, relPath is just the file's name; for a leaf inside
 // Subs/, relPath is "Subs/<name>".
 func (c *Client) GetAllTransferFiles(ctx context.Context, fileID int64) ([]TransferFile, error) {
-	file, err := c.client.Files.Get(ctx, fileID)
+	// Only the root Files.Get is wrapped here; the recursive walk calls
+	// c.GetFiles, which already applies the rate-limit retry, so wrapping it
+	// again would double-retry.
+	var file putio.File
+	err := c.withRateLimitRetry(ctx, "files.get", func() error {
+		var e error
+		file, e = c.client.Files.Get(ctx, fileID)
+		return e
+	})
 	if err != nil {
 		return nil, fmt.Errorf("get transfer files: %w", err)
 	}
@@ -215,7 +284,12 @@ func (c *Client) GetAllTransferFiles(ctx context.Context, fileID int64) ([]Trans
 
 // RetryTransfer retries a failed transfer
 func (c *Client) RetryTransfer(ctx context.Context, transferID int64) (*putio.Transfer, error) {
-	transfer, err := c.client.Transfers.Retry(ctx, transferID)
+	var transfer putio.Transfer
+	err := c.withRateLimitRetry(ctx, "transfers.retry", func() error {
+		var e error
+		transfer, e = c.client.Transfers.Retry(ctx, transferID)
+		return e
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to retry transfer: %w", err)
 	}

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/doodla/go-putio"
+	"github.com/doodla/plundrio/internal/log"
+)
+
+// Rate-limit retry tuning. These govern how api.Client reacts to put.io HTTP
+// 429 (Too Many Requests) responses on the JSON API path. The file-download
+// (grab/CDN) path has its own transient-error handling in
+// internal/download/download.go and is unaffected.
+const (
+	rlBaseBackoff = 1 * time.Second
+	rlMaxBackoff  = 60 * time.Second
+	// rlMaxRetries is the number of retries AFTER the initial attempt. Once
+	// exhausted the last 429 error is returned to the caller so the failure
+	// surfaces (logged, monitor tick dropped) rather than blocking forever.
+	// Kept modest so a sustained throttle can't wedge the single monitor
+	// goroutine for long — the 30s poll loop provides a coarse retry on top.
+	rlMaxRetries = 3
+)
+
+// isRateLimited reports whether err is a put.io HTTP 429 and, if so, the
+// Retry-After delay parsed from the response headers (0 when absent or
+// unparseable). It walks the wrap chain with errors.As — the same pattern as
+// download.isNotFoundError — because every api.Client method wraps its error
+// with fmt.Errorf("...: %w", err).
+func isRateLimited(err error) (retryAfter time.Duration, ok bool) {
+	var putioErr *putio.ErrorResponse
+	if !errors.As(err, &putioErr) || putioErr.Response == nil {
+		return 0, false
+	}
+	if putioErr.Response.StatusCode != http.StatusTooManyRequests {
+		return 0, false
+	}
+	return retryAfterFromHeader(putioErr.Response.Header), true
+}
+
+// retryAfterFromHeader parses a Retry-After header value, which per RFC 7231 is
+// EITHER an integer number of seconds ("120") OR an HTTP-date. Returns 0 when
+// the header is absent or unparseable, and clamps a past HTTP-date to 0.
+func retryAfterFromHeader(h http.Header) time.Duration {
+	if h == nil {
+		return 0
+	}
+	v := strings.TrimSpace(h.Get("Retry-After"))
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// backoffDelay computes the delay before retry attempt n (0-based) using
+// exponential backoff with full jitter, capped at rlMaxBackoff. A server-
+// supplied Retry-After takes precedence (we honor the server) but is still
+// capped at rlMaxBackoff so a garbage/hostile header can't wedge the caller.
+func backoffDelay(attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		if retryAfter > rlMaxBackoff {
+			return rlMaxBackoff
+		}
+		return retryAfter
+	}
+	// base * 2^attempt, capped. attempt is bounded by rlMaxRetries so the shift
+	// cannot overflow, but guard defensively against a negative/oversized value.
+	d := rlMaxBackoff
+	if attempt >= 0 && attempt < 32 {
+		if shifted := rlBaseBackoff << uint(attempt); shifted > 0 && shifted < rlMaxBackoff {
+			d = shifted
+		}
+	}
+	// Full jitter: uniformly random in [d/2, d].
+	half := d / 2
+	return half + time.Duration(rand.Int63n(int64(half)+1))
+}
+
+// withRateLimitRetry runs fn, retrying on a put.io HTTP 429 with exponential
+// backoff plus jitter (honoring Retry-After when present). Non-429 errors and
+// success return immediately. Backoff respects ctx cancellation between
+// attempts. After rlMaxRetries are exhausted it returns the last 429 error so
+// callers still observe a failure instead of blocking indefinitely.
+func (c *Client) withRateLimitRetry(ctx context.Context, op string, fn func() error) error {
+	for attempt := 0; ; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		retryAfter, limited := isRateLimited(err)
+		if !limited {
+			return err
+		}
+		if attempt >= rlMaxRetries {
+			log.Error("api").Str("op", op).Int("attempts", attempt+1).
+				Msg("put.io rate limit retries exhausted; surfacing error to caller")
+			return err
+		}
+		delay := backoffDelay(attempt, retryAfter)
+		log.Warn("api").
+			Str("op", op).
+			Int("attempt", attempt+1).
+			Int("max_attempts", rlMaxRetries+1).
+			Dur("backoff", delay).
+			Dur("retry_after", retryAfter).
+			Msg("put.io rate limited (HTTP 429); backing off")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.sleeper(delay):
+		}
+	}
+}

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -98,6 +98,15 @@ func backoffDelay(attempt int, retryAfter time.Duration) time.Duration {
 // success return immediately. Backoff respects ctx cancellation between
 // attempts. After rlMaxRetries are exhausted it returns the last 429 error so
 // callers still observe a failure instead of blocking indefinitely.
+//
+// Why per-method wrapping rather than a transport-level http.RoundTripper
+// (which would cover every call automatically): a retried request must replay
+// its body, and UploadFile's body is a consumed io.Reader. The underlying
+// go-putio client doesn't set Request.GetBody, so a RoundTripper couldn't
+// safely re-send an upload — whereas wrapping at this layer lets UploadFile
+// rebuild its bytes.Reader per attempt (see client.go). The cost is that a new
+// client method must opt in by wrapping its call; that's the deliberate
+// trade. Do NOT double-wrap recursive helpers (see GetAllTransferFiles).
 func (c *Client) withRateLimitRetry(ctx context.Context, op string, fn func() error) error {
 	for attempt := 0; ; attempt++ {
 		err := fn()

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -1,0 +1,221 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/doodla/go-putio"
+)
+
+// putioErrorWith builds a wrapped *putio.ErrorResponse with the given HTTP
+// status and optional headers, matching the shape the real client returns
+// (fmt.Errorf with %w). Request is populated because ErrorResponse.Error()
+// dereferences it during formatting.
+func putioErrorWith(statusCode int, header http.Header) error {
+	req, _ := http.NewRequest(http.MethodGet, "https://api.put.io/v2/transfers/list", nil)
+	resp := &http.Response{StatusCode: statusCode, Header: header, Request: req}
+	return fmt.Errorf("get transfers: %w", &putio.ErrorResponse{Response: resp})
+}
+
+func rateLimitErr(retryAfter string) error {
+	h := http.Header{}
+	if retryAfter != "" {
+		h.Set("Retry-After", retryAfter)
+	}
+	return putioErrorWith(http.StatusTooManyRequests, h)
+}
+
+func instantSleeper(time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	ch <- time.Now()
+	return ch
+}
+
+// blockingSleeper never fires, forcing the withRateLimitRetry select to take
+// the ctx.Done() arm — used to test cancellation deterministically.
+func blockingSleeper(time.Duration) <-chan time.Time { return make(chan time.Time) }
+
+func TestRetryAfterFromHeader(t *testing.T) {
+	future := time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)
+	past := time.Now().Add(-30 * time.Second).UTC().Format(http.TimeFormat)
+
+	tests := []struct {
+		name   string
+		value  string
+		min    time.Duration
+		max    time.Duration
+		absent bool
+	}{
+		{"seconds", "120", 120 * time.Second, 120 * time.Second, false},
+		{"zero", "0", 0, 0, true},
+		{"negative", "-5", 0, 0, true},
+		{"empty", "", 0, 0, true},
+		{"garbage", "soon", 0, 0, true},
+		{"http_date_future", future, 25 * time.Second, 31 * time.Second, false},
+		{"http_date_past", past, 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.Header{}
+			if tt.value != "" {
+				h.Set("Retry-After", tt.value)
+			}
+			got := retryAfterFromHeader(h)
+			if tt.absent {
+				if got != 0 {
+					t.Fatalf("want 0, got %v", got)
+				}
+				return
+			}
+			if got < tt.min || got > tt.max {
+				t.Fatalf("want within [%v,%v], got %v", tt.min, tt.max, got)
+			}
+		})
+	}
+	if got := retryAfterFromHeader(nil); got != 0 {
+		t.Fatalf("nil header: want 0, got %v", got)
+	}
+}
+
+func TestBackoffDelay(t *testing.T) {
+	// Server-supplied Retry-After wins and is exact (no jitter), capped.
+	if got := backoffDelay(0, 5*time.Second); got != 5*time.Second {
+		t.Fatalf("retry-after honored: want 5s, got %v", got)
+	}
+	if got := backoffDelay(0, 5*time.Minute); got != rlMaxBackoff {
+		t.Fatalf("retry-after cap: want %v, got %v", rlMaxBackoff, got)
+	}
+
+	// Exponential growth with full jitter: delay in [base/2, base] per attempt.
+	for attempt, base := range map[int]time.Duration{
+		0: 1 * time.Second,
+		1: 2 * time.Second,
+		2: 4 * time.Second,
+	} {
+		for i := 0; i < 50; i++ {
+			got := backoffDelay(attempt, 0)
+			if got < base/2 || got > base {
+				t.Fatalf("attempt %d: want [%v,%v], got %v", attempt, base/2, base, got)
+			}
+		}
+	}
+
+	// Large/overflowing attempt is capped at rlMaxBackoff (with jitter floor).
+	got := backoffDelay(40, 0)
+	if got < rlMaxBackoff/2 || got > rlMaxBackoff {
+		t.Fatalf("overflow attempt: want [%v,%v], got %v", rlMaxBackoff/2, rlMaxBackoff, got)
+	}
+}
+
+func TestIsRateLimited(t *testing.T) {
+	if ra, ok := isRateLimited(nil); ok || ra != 0 {
+		t.Fatalf("nil: want (0,false), got (%v,%v)", ra, ok)
+	}
+	if _, ok := isRateLimited(errors.New("boom")); ok {
+		t.Fatalf("plain error: want false")
+	}
+	if _, ok := isRateLimited(putioErrorWith(http.StatusNotFound, nil)); ok {
+		t.Fatalf("404: want false")
+	}
+	if _, ok := isRateLimited(&putio.ErrorResponse{Response: nil}); ok {
+		t.Fatalf("nil response: want false")
+	}
+	ra, ok := isRateLimited(rateLimitErr(""))
+	if !ok || ra != 0 {
+		t.Fatalf("429 no header: want (0,true), got (%v,%v)", ra, ok)
+	}
+	ra, ok = isRateLimited(rateLimitErr("5"))
+	if !ok || ra != 5*time.Second {
+		t.Fatalf("429 with Retry-After: want (5s,true), got (%v,%v)", ra, ok)
+	}
+}
+
+func TestWithRateLimitRetrySuccess(t *testing.T) {
+	c := &Client{sleeper: instantSleeper}
+	calls := 0
+	err := c.withRateLimitRetry(context.Background(), "test", func() error {
+		calls++
+		return nil
+	})
+	if err != nil || calls != 1 {
+		t.Fatalf("want (nil,1 call), got (%v,%d)", err, calls)
+	}
+}
+
+func TestWithRateLimitRetryRecovers(t *testing.T) {
+	c := &Client{sleeper: instantSleeper}
+	calls := 0
+	err := c.withRateLimitRetry(context.Background(), "test", func() error {
+		calls++
+		if calls <= 2 {
+			return rateLimitErr("")
+		}
+		return nil
+	})
+	if err != nil || calls != 3 {
+		t.Fatalf("want (nil,3 calls), got (%v,%d)", err, calls)
+	}
+}
+
+func TestWithRateLimitRetryExhausts(t *testing.T) {
+	c := &Client{sleeper: instantSleeper}
+	calls := 0
+	err := c.withRateLimitRetry(context.Background(), "test", func() error {
+		calls++
+		return rateLimitErr("")
+	})
+	if _, ok := isRateLimited(err); !ok {
+		t.Fatalf("want a 429 error returned, got %v", err)
+	}
+	if calls != rlMaxRetries+1 {
+		t.Fatalf("want %d calls, got %d", rlMaxRetries+1, calls)
+	}
+}
+
+func TestWithRateLimitRetryNon429Immediate(t *testing.T) {
+	c := &Client{sleeper: instantSleeper}
+	calls := 0
+	sentinel := putioErrorWith(http.StatusInternalServerError, nil)
+	err := c.withRateLimitRetry(context.Background(), "test", func() error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) || calls != 1 {
+		t.Fatalf("want (sentinel,1 call), got (%v,%d)", err, calls)
+	}
+}
+
+func TestWithRateLimitRetryContextCancelled(t *testing.T) {
+	c := &Client{sleeper: blockingSleeper}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	err := c.withRateLimitRetry(ctx, "test", func() error {
+		calls++
+		return rateLimitErr("")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("want 1 call before cancel, got %d", calls)
+	}
+}
+
+// TestWithRateLimitRetryPreservesErrorChain guards orphan-recovery: a 404
+// surfaced through the wrapper must keep its %w chain so errors.As still
+// unwraps the *putio.ErrorResponse (download.isNotFoundError depends on this).
+func TestWithRateLimitRetryPreservesErrorChain(t *testing.T) {
+	c := &Client{sleeper: instantSleeper}
+	err := c.withRateLimitRetry(context.Background(), "test", func() error {
+		return putioErrorWith(http.StatusNotFound, nil)
+	})
+	var putioErr *putio.ErrorResponse
+	if !errors.As(err, &putioErr) || putioErr.Response.StatusCode != http.StatusNotFound {
+		t.Fatalf("404 chain not preserved through wrapper: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,4 +78,23 @@ type Config struct {
 	// directly must set this field explicitly or the janitor silently
 	// won't run.
 	PostCompleteRetention time.Duration `mapstructure:"post_complete_retention"`
+
+	// StallTimeout is how long a put.io transfer may sit in a non-terminal
+	// status (IN_QUEUE/WAITING/PREPARING/DOWNLOADING) without making progress
+	// before plundrio treats it as stalled — a torrent with no seeders never
+	// reaches ERROR on put.io, so without this guard *arr waits forever.
+	// On a stall the transfer is retried up to StallMaxRetries times, then
+	// deleted so *arr can grab a different release.
+	//
+	// Default-construction footgun (same as PostCompleteRetention): the Go zero
+	// value (0) means "use the package default" (1h), NOT "stall instantly".
+	// download.New applies it only when >0; the CLI flag injects the real 1h
+	// default. Keep the threshold generous — put.io legitimately queues for
+	// minutes on a cold magnet.
+	StallTimeout time.Duration `mapstructure:"stall_timeout"`
+
+	// StallMaxRetries is how many times a stalled transfer is retried before
+	// being deleted. 0 = delete on first stall (no retry). Only applied
+	// alongside StallTimeout (see download.New); the CLI flag default is 1.
+	StallMaxRetries int `mapstructure:"stall_max_retries"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,4 +97,14 @@ type Config struct {
 	// being deleted. 0 = delete on first stall (no retry). Only applied
 	// alongside StallTimeout (see download.New); the CLI flag default is 1.
 	StallMaxRetries int `mapstructure:"stall_max_retries"`
+
+	// MinFreeSpace is an opt-in floor on put.io free space (AccountInfo.Disk.Avail)
+	// below which torrent-add is rejected, so *arr fails the grab and tries
+	// another release instead of queueing a download put.io has no room for.
+	// Human-readable (e.g. "20GB", "10GiB"); empty string disables the check.
+	// Stored as a string (parsed via ParseByteSize at use, like
+	// DownloadStartWindow's "HH:MM" strings) so it plumbs through viper/env/yaml
+	// with no custom decode hook. The check fails OPEN: if the put.io account
+	// lookup errors, the add proceeds — this is a safety floor, not a hard gate.
+	MinFreeSpace string `mapstructure:"min_free_space"`
 }

--- a/internal/config/size.go
+++ b/internal/config/size.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// ParseByteSize parses a human-readable size string into a byte count.
+//
+// Accepted forms (case-insensitive, optional space before the unit):
+//
+//	""              -> 0      (the documented "disabled / unset" value)
+//	"1024", "1024B" -> 1024 bytes
+//	"10KB"/"10MB"/"10GB"/"10TB"    -> decimal (×1000)
+//	"10KiB"/"10MiB"/"10GiB"/"10TiB" -> binary  (×1024)
+//
+// Fractional values ("1.5GiB") are allowed and rounded down to whole bytes.
+// Negative, malformed, or unknown-unit inputs are rejected. The decimal/binary
+// split matches the convention operators expect from `df`-style tooling: GB is
+// 10^9, GiB is 2^30.
+func ParseByteSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+
+	// Split the leading numeric run from the trailing unit. The number may
+	// carry a sign and a decimal point; everything after is the unit.
+	i := 0
+	for i < len(s) && (s[i] == '.' || s[i] == '-' || s[i] == '+' || (s[i] >= '0' && s[i] <= '9')) {
+		i++
+	}
+	numStr := strings.TrimSpace(s[:i])
+	unit := strings.ToUpper(strings.TrimSpace(s[i:]))
+	if numStr == "" {
+		return 0, fmt.Errorf("invalid size %q: missing numeric value", s)
+	}
+
+	val, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size %q: %w", s, err)
+	}
+	if val < 0 {
+		return 0, fmt.Errorf("invalid size %q: must not be negative", s)
+	}
+
+	var mult float64
+	switch unit {
+	case "", "B":
+		mult = 1
+	case "KB":
+		mult = 1e3
+	case "MB":
+		mult = 1e6
+	case "GB":
+		mult = 1e9
+	case "TB":
+		mult = 1e12
+	case "KIB":
+		mult = 1 << 10
+	case "MIB":
+		mult = 1 << 20
+	case "GIB":
+		mult = 1 << 30
+	case "TIB":
+		mult = 1 << 40
+	default:
+		return 0, fmt.Errorf("invalid size %q: unknown unit %q", s, unit)
+	}
+
+	bytes := val * mult
+	// float64 can't represent math.MaxInt64 exactly — it rounds up to 2^63 — so
+	// both sides promote to the same 2^63 float and ">=" rejects the exact-2^63
+	// case (which would otherwise wrap negative through int64()). Anything below
+	// rounds to a representable value <= MaxInt64-1024 and converts safely.
+	if bytes >= math.MaxInt64 {
+		return 0, fmt.Errorf("invalid size %q: exceeds maximum", s)
+	}
+	return int64(bytes), nil
+}

--- a/internal/config/size_test.go
+++ b/internal/config/size_test.go
@@ -1,0 +1,47 @@
+package config
+
+import "testing"
+
+func TestParseByteSize(t *testing.T) {
+	tests := []struct {
+		in   string
+		want int64
+	}{
+		{"", 0},
+		{"   ", 0},
+		{"0", 0},
+		{"1024", 1024},
+		{"1024B", 1024},
+		{"512 b", 512},
+		{"10KB", 10_000},
+		{"10MB", 10_000_000},
+		{"2GB", 2_000_000_000},
+		{"1TB", 1_000_000_000_000},
+		{"1KiB", 1024},
+		{"1MiB", 1 << 20},
+		{"10GiB", 10 * (1 << 30)},
+		{"1TiB", 1 << 40},
+		{"1.5GiB", int64(1.5 * (1 << 30))},
+		{"20 gb", 20_000_000_000}, // case-insensitive + space
+	}
+	for _, tt := range tests {
+		got, err := ParseByteSize(tt.in)
+		if err != nil {
+			t.Errorf("ParseByteSize(%q) unexpected error: %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseByteSize(%q) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseByteSizeErrors(t *testing.T) {
+	// "8388608TiB" == 2^23 * 2^40 == 2^63, the exact int64 overflow boundary
+	// that float64 rounding would otherwise sneak past into a negative wrap.
+	for _, in := range []string{"-1", "-5GB", "abc", "GB", "10XB", "10 PB", "1.2.3MB", "8388608TiB"} {
+		if got, err := ParseByteSize(in); err == nil {
+			t.Errorf("ParseByteSize(%q) = %d, want error", in, got)
+		}
+	}
+}

--- a/internal/download/config.go
+++ b/internal/download/config.go
@@ -27,6 +27,17 @@ type DownloadConfig struct {
 
 	// CopyTimeout is the timeout for waiting for the copy operation to complete after cancellation
 	CopyTimeout time.Duration
+
+	// StallTimeout is how long a put.io transfer may sit in a non-terminal
+	// status (IN_QUEUE/WAITING/PREPARING/DOWNLOADING) making no progress before
+	// it is treated as stalled and retried/surfaced. Distinct from
+	// DownloadStallTimeout, which governs the local CDN download, not the
+	// put.io-side fetch.
+	StallTimeout time.Duration
+
+	// StallMaxRetries is how many times a stalled put.io transfer is retried
+	// (via RetryTransfer) before being deleted. 0 = delete on first stall.
+	StallMaxRetries int
 }
 
 // GetDefaultConfig returns a DownloadConfig with reasonable default values
@@ -40,5 +51,7 @@ func GetDefaultConfig() *DownloadConfig {
 		DownloadHeaderTimeout:  30 * time.Second, // 30 second timeout for response headers
 		DownloadStallTimeout:   2 * time.Minute,  // Cancel download if stalled for 2 minutes
 		CopyTimeout:            10 * time.Second, // Wait 10 seconds for copy to complete after cancellation
+		StallTimeout:           1 * time.Hour,    // Treat a no-progress put.io transfer as stalled after 1h
+		StallMaxRetries:        1,                // Retry a stalled transfer once before deleting it
 	}
 }

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -111,6 +111,17 @@ func New(cfg *config.Config, client PutioClient) *Manager {
 		dlConfig.TransferCheckInterval = cfg.TransferCheckInterval
 	}
 
+	// Stall handling: a configured (>0) StallTimeout opts in to the operator's
+	// values for both the timeout and the retry count; otherwise the package
+	// defaults (1h / 1 retry) stand. StallMaxRetries==0 is a meaningful value
+	// (delete on first stall), so it is only honored when StallTimeout signals
+	// the operator configured stall handling — a default-constructed Config
+	// (tests/demo) keeps the 1-retry default.
+	if cfg.StallTimeout > 0 {
+		dlConfig.StallTimeout = cfg.StallTimeout
+		dlConfig.StallMaxRetries = cfg.StallMaxRetries
+	}
+
 	// Override with user config if provided
 	workerCount := cfg.WorkerCount
 	if workerCount <= 0 {

--- a/internal/download/transfers.go
+++ b/internal/download/transfers.go
@@ -24,7 +24,7 @@ import (
 type TransferProcessor struct {
 	manager            *Manager
 	transfers          atomic.Pointer[map[string][]*putio.Transfer] // Status -> Transfers (immutable once published)
-	processedTransfers sync.Map // map[int64]bool - Tracks transfers that have been processed locally
+	processedTransfers sync.Map                                     // map[int64]bool - Tracks transfers that have been processed locally
 
 	// retryAttempts and failedRetryStates back two distinct retry paths.
 	// retryAttempts: retry-count for transfers in put.io status "ERROR"
@@ -39,8 +39,23 @@ type TransferProcessor struct {
 	// The two paths operate on disjoint conditions and don't share state.
 	retryAttempts     sync.Map // map[int64]int — see comment above
 	failedRetryStates sync.Map // map[int64]*localRetryState — see comment above
-	folderID           int64
-	targetDir          string
+
+	// stallStates backs a third, disjoint path: transfers wedged in a
+	// non-terminal put.io status (IN_QUEUE/WAITING/PREPARING/DOWNLOADING)
+	// making no progress. Unlike the other two, these transfers have NO
+	// coordinator TransferContext yet (one is created only once a transfer
+	// reaches COMPLETED/SEEDING), so their stall timer can't live there — it
+	// lives here, keyed by put.io transfer ID. Driven by processStalledTransfers;
+	// disjoint from retryAttempts (ERROR status) and failedRetryStates (local
+	// download failures). See processStalledTransfersAt.
+	stallStates sync.Map // map[int64]*putioStallState
+	folderID    int64
+	targetDir   string
+
+	// stallTimeout / stallMaxRetries are cached from dlConfig at construction
+	// (single-writer monitor goroutine reads them). Tests override them directly.
+	stallTimeout    time.Duration
+	stallMaxRetries int
 
 	// lastSummaryCounts caches the last status-count map logged by
 	// logTransferSummary so subsequent ticks with identical counts can
@@ -110,6 +125,8 @@ func newTransferProcessor(m *Manager) *TransferProcessor {
 		retryAttempts:      sync.Map{},
 		folderID:           m.cfg.FolderID,
 		targetDir:          m.cfg.TargetDir,
+		stallTimeout:       m.dlConfig.StallTimeout,
+		stallMaxRetries:    m.dlConfig.StallMaxRetries,
 	}
 	empty := map[string][]*putio.Transfer{}
 	p.transfers.Store(&empty)
@@ -217,6 +234,9 @@ func (p *TransferProcessor) checkTransfers() {
 
 	// Process transfers by status
 	p.processReadyTransfers()
+	// Stall scan runs after processReadyTransfers so a transfer that just became
+	// ready this tick is initiated for download rather than mistaken for stalled.
+	p.processStalledTransfers()
 	p.processFailedTransfers()
 	p.processErroredTransfers()
 
@@ -714,6 +734,163 @@ func (p *TransferProcessor) processErroredTransfers() {
 			}
 		}
 	}
+}
+
+// nonTerminalPutioStatuses are the put.io statuses a transfer passes through
+// before it is ready (COMPLETED/SEEDING) or has failed (ERROR). COMPLETING is
+// deliberately excluded: it is short-lived, post-download, and exposes no
+// per-byte progress signal, so a slow finalize on a large transfer must not be
+// mistaken for a stall.
+var nonTerminalPutioStatuses = map[string]bool{
+	"IN_QUEUE":    true,
+	"WAITING":     true,
+	"PREPARING":   true,
+	"DOWNLOADING": true,
+}
+
+// putioStallState tracks, per put.io transfer ID, how long a transfer has sat
+// in a non-terminal status without progress. Mutated in place on the monitor
+// goroutine only (like localRetryState), so no internal locking is needed.
+type putioStallState struct {
+	Status         string    // last observed put.io status
+	StatusSince    time.Time // when the current no-progress window started
+	LastDownloaded int64     // last observed Transfer.Downloaded
+	LastPercent    int       // last observed Transfer.PercentDone
+	RetryCount     int       // stall-driven RetryTransfer calls made so far
+	RetriedAt      time.Time // when the most recent stall retry fired
+}
+
+// processStalledTransfers retries or deletes transfers wedged in a non-terminal
+// put.io status with no progress. See processStalledTransfersAt.
+func (p *TransferProcessor) processStalledTransfers() {
+	p.processStalledTransfersAt(time.Now())
+}
+
+// processStalledTransfersAt is the testable seam for processStalledTransfers
+// (clock injected), mirroring processFailedTransfersAt. A transfer is stalled
+// when it has been in the same non-terminal status with no byte/percent
+// progress for longer than stallTimeout. On a stall it is retried up to
+// stallMaxRetries times (each retry grants a fresh full window), then deleted —
+// the same give-up shape processErroredTransfers uses, surfacing to *arr via
+// the transfer disappearing from torrent-get.
+//
+// This path is disjoint from the other two: it only acts on
+// nonTerminalPutioStatuses, while processErroredTransfers handles ERROR and
+// processFailedTransfers handles transfers already in TransferLifecycleFailed
+// (which by definition reached COMPLETED/SEEDING first).
+func (p *TransferProcessor) processStalledTransfersAt(now time.Time) {
+	transfers := p.loadTransfers()
+
+	// Track every non-terminal transfer ID seen this tick so stallStates can be
+	// pruned of entries that completed, errored, or were purged — preventing the
+	// map from leaking across the process lifetime.
+	seen := make(map[int64]struct{})
+
+	for status := range nonTerminalPutioStatuses {
+		for _, t := range transfers[status] {
+			if t.SaveParentID != p.folderID {
+				continue
+			}
+			seen[t.ID] = struct{}{}
+			p.evaluateStall(t, now)
+		}
+	}
+
+	p.stallStates.Range(func(key, _ any) bool {
+		if _, ok := seen[key.(int64)]; !ok {
+			p.stallStates.Delete(key)
+		}
+		return true
+	})
+}
+
+// evaluateStall advances a single non-terminal transfer's stall state and acts
+// when it trips the timeout. Called only from processStalledTransfersAt on the
+// monitor goroutine, so in-place mutation of *putioStallState is safe.
+func (p *TransferProcessor) evaluateStall(t *putio.Transfer, now time.Time) {
+	stateValue, loaded := p.stallStates.LoadOrStore(t.ID, &putioStallState{
+		Status:         t.Status,
+		StatusSince:    now,
+		LastDownloaded: t.Downloaded,
+		LastPercent:    t.PercentDone,
+	})
+	if !loaded {
+		// First observation — start its window, nothing to decide yet.
+		return
+	}
+	st := stateValue.(*putioStallState)
+
+	// Only data movement counts as progress. put.io status churn among the
+	// non-terminal states is NOT progress: a seederless magnet bounces
+	// IN_QUEUE<->DOWNLOADING on successive polls, and refreshing the window on
+	// a status change would reset the clock every tick so the timeout never
+	// trips — the transfer would never be recovered, the exact bug this guards
+	// against. Byte movement in either direction counts (a retry can reset
+	// put.io's counter), so an actively (re)downloading transfer is never
+	// killed.
+	dataActivity := t.Downloaded != st.LastDownloaded || t.PercentDone != st.LastPercent
+	st.Status = t.Status
+	st.LastDownloaded = t.Downloaded
+	st.LastPercent = t.PercentDone
+	if dataActivity {
+		// Alive — refresh the window. RetryCount is deliberately NOT reset
+		// here: it is bounded across the transfer's entire non-terminal
+		// lifetime so our own retries (which reset put.io's byte counter) can't
+		// grant unlimited fresh budget. A transfer that truly recovers reaches
+		// COMPLETED/SEEDING, leaves the non-terminal set, and is pruned —
+		// resetting the budget naturally.
+		st.StatusSince = now
+		return
+	}
+
+	if now.Sub(st.StatusSince) < p.stallTimeout {
+		return
+	}
+
+	if st.RetryCount < p.stallMaxRetries {
+		st.RetryCount++
+		st.RetriedAt = now
+		st.StatusSince = now // grant the retried transfer a fresh full window
+		log.Warn("transfers").
+			Int64("id", t.ID).
+			Str("name", t.Name).
+			Str("status", t.Status).
+			Dur("stalled_for", p.stallTimeout).
+			Int64("downloaded", t.Downloaded).
+			Int("percent_done", t.PercentDone).
+			Str("status_message", t.StatusMessage).
+			Int("retry", st.RetryCount).
+			Int("max_retries", p.stallMaxRetries).
+			Msg("Transfer stalled on put.io with no progress, retrying")
+		if _, err := p.manager.client.RetryTransfer(p.manager.Context(), t.ID); err != nil {
+			// Tolerate the error — re-evaluate next window rather than escalate.
+			log.Error("transfers").
+				Int64("id", t.ID).
+				Str("name", t.Name).
+				Err(err).
+				Msg("Failed to retry stalled transfer")
+		}
+		return
+	}
+
+	// Retries exhausted — give up and delete so the put.io transfer slot frees
+	// and the transfer vanishes from torrent-get (which *arr treats as removal,
+	// then re-grabs a different release).
+	log.Error("transfers").
+		Int64("id", t.ID).
+		Str("name", t.Name).
+		Str("status", t.Status).
+		Int("retries", st.RetryCount).
+		Msg("Transfer stalled on put.io past retry budget, deleting")
+	if err := p.manager.client.DeleteTransfer(p.manager.Context(), t.ID); err != nil {
+		log.Error("transfers").
+			Int64("id", t.ID).
+			Str("name", t.Name).
+			Err(err).
+			Msg("Failed to delete stalled transfer")
+		return
+	}
+	p.stallStates.Delete(t.ID)
 }
 
 // MarkTransferProcessed marks a transfer as processed locally

--- a/internal/download/transfers_test.go
+++ b/internal/download/transfers_test.go
@@ -81,6 +81,237 @@ func makeTransferFile(id int64, size int64) api.TransferFile {
 	return api.TransferFile{File: f, RelPath: f.Name}
 }
 
+// getStallStateForTest returns the processor's putioStallState for a transfer,
+// failing the test if absent.
+func getStallStateForTest(t *testing.T, p *TransferProcessor, id int64) *putioStallState {
+	t.Helper()
+	v, ok := p.stallStates.Load(id)
+	if !ok {
+		t.Fatalf("no putioStallState for transfer %d", id)
+	}
+	return v.(*putioStallState)
+}
+
+// stallCallCounts reads the fake client's recorded retry/delete calls under its
+// lock.
+func stallCallCounts(c *fakePutioClient) (retries, deletes int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.retryTransferCalls), len(c.deleteTransferCalls)
+}
+
+func TestProcessStalledTransfersNoStallBeforeTimeout(t *testing.T) {
+	client := &fakePutioClient{}
+	p := newTestManagerWithClient(client).processor
+	base := time.Now()
+
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 0})
+	p.processStalledTransfersAt(base) // first observation
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 0})
+	p.processStalledTransfersAt(base.Add(30 * time.Minute)) // well under 1h
+
+	if r, d := stallCallCounts(client); r != 0 || d != 0 {
+		t.Fatalf("expected no retry/delete before timeout, got retries=%d deletes=%d", r, d)
+	}
+	if st := getStallStateForTest(t, p, 1); !st.StatusSince.Equal(base) {
+		t.Fatalf("StatusSince = %v, want %v", st.StatusSince, base)
+	}
+}
+
+func TestProcessStalledTransfersDataProgressResetsWindow(t *testing.T) {
+	client := &fakePutioClient{}
+	p := newTestManagerWithClient(client).processor
+	base := time.Now()
+
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 0})
+	p.processStalledTransfersAt(base)
+	// Bytes advanced at base+50m — resets the window to base+50m.
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 1000})
+	p.processStalledTransfersAt(base.Add(50 * time.Minute))
+	// At base+80m only 30m has elapsed since the reset; without the reset it
+	// would have been 80m >= 1h and tripped a stall.
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 1000})
+	p.processStalledTransfersAt(base.Add(80 * time.Minute))
+
+	if r, d := stallCallCounts(client); r != 0 || d != 0 {
+		t.Fatalf("data progress must reset the window, got retries=%d deletes=%d", r, d)
+	}
+	st := getStallStateForTest(t, p, 1)
+	if !st.StatusSince.Equal(base.Add(50 * time.Minute)) {
+		t.Fatalf("StatusSince = %v, want %v (reset on byte progress)", st.StatusSince, base.Add(50*time.Minute))
+	}
+}
+
+func TestProcessStalledTransfersRetriesThenDeletes(t *testing.T) {
+	client := &fakePutioClient{}
+	p := newTestManagerWithClient(client).processor // defaults: 1h timeout, 1 retry
+	base := time.Now()
+
+	tr := &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 0}
+	setPutioTransfers(p, tr)
+	p.processStalledTransfersAt(base) // observe
+
+	// Stage 1: no progress past the timeout -> one RetryTransfer.
+	setPutioTransfers(p, tr)
+	p.processStalledTransfersAt(base.Add(61 * time.Minute))
+	if r, d := stallCallCounts(client); r != 1 || d != 0 {
+		t.Fatalf("stage 1: want retries=1 deletes=0, got retries=%d deletes=%d", r, d)
+	}
+	st := getStallStateForTest(t, p, 1)
+	if st.RetryCount != 1 || !st.StatusSince.Equal(base.Add(61*time.Minute)) {
+		t.Fatalf("stage 1 state: RetryCount=%d StatusSince=%v", st.RetryCount, st.StatusSince)
+	}
+
+	// Stage 2: still no progress a full window after the retry -> DeleteTransfer.
+	setPutioTransfers(p, tr)
+	p.processStalledTransfersAt(base.Add(122 * time.Minute))
+	if r, d := stallCallCounts(client); r != 1 || d != 1 {
+		t.Fatalf("stage 2: want retries=1 deletes=1, got retries=%d deletes=%d", r, d)
+	}
+	if _, ok := p.stallStates.Load(int64(1)); ok {
+		t.Fatalf("stall state should be deleted after give-up delete")
+	}
+}
+
+func TestProcessStalledTransfersZeroMaxRetriesDeletesImmediately(t *testing.T) {
+	client := &fakePutioClient{}
+	p := newTestManagerWithClient(client).processor
+	p.stallMaxRetries = 0
+	base := time.Now()
+
+	tr := &putio.Transfer{ID: 7, Status: "IN_QUEUE"}
+	setPutioTransfers(p, tr)
+	p.processStalledTransfersAt(base)
+	setPutioTransfers(p, tr)
+	p.processStalledTransfersAt(base.Add(61 * time.Minute))
+
+	if r, d := stallCallCounts(client); r != 0 || d != 1 {
+		t.Fatalf("zero max-retries: want retries=0 deletes=1, got retries=%d deletes=%d", r, d)
+	}
+}
+
+// TestProcessStalledTransfersStatusChurnStillStalls is the regression guard for
+// the flip-flop bug: a seederless magnet bounces between non-terminal statuses
+// every poll with frozen bytes. Status churn must NOT refresh the window, or
+// the timeout never trips and the transfer is never recovered.
+func TestProcessStalledTransfersStatusChurnStillStalls(t *testing.T) {
+	client := &fakePutioClient{}
+	p := newTestManagerWithClient(client).processor // 1h timeout, 1 retry
+	base := time.Now()
+
+	// Bytes frozen at 0 throughout; only the status oscillates each tick.
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 0})
+	p.processStalledTransfersAt(base)
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "IN_QUEUE", Downloaded: 0})
+	p.processStalledTransfersAt(base.Add(30 * time.Minute))
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 0})
+	p.processStalledTransfersAt(base.Add(61 * time.Minute)) // 61m since base, frozen -> stall
+
+	if r, d := stallCallCounts(client); r != 1 || d != 0 {
+		t.Fatalf("status churn must not prevent stall: want retries=1 deletes=0, got retries=%d deletes=%d", r, d)
+	}
+
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "IN_QUEUE", Downloaded: 0})
+	p.processStalledTransfersAt(base.Add(91 * time.Minute))
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 0})
+	p.processStalledTransfersAt(base.Add(122 * time.Minute)) // full window after retry -> delete
+
+	if r, d := stallCallCounts(client); r != 1 || d != 1 {
+		t.Fatalf("churning stalled transfer must be deleted: want retries=1 deletes=1, got retries=%d deletes=%d", r, d)
+	}
+}
+
+// TestProcessStalledTransfersRetryBudgetSurvivesActivity verifies the retry
+// budget is bounded across the non-terminal lifetime: data activity refreshes
+// the window (so an active transfer isn't killed) but does NOT reset RetryCount,
+// so a transfer that keeps stalling is still eventually deleted.
+func TestProcessStalledTransfersRetryBudgetSurvivesActivity(t *testing.T) {
+	client := &fakePutioClient{}
+	p := newTestManagerWithClient(client).processor // 1h timeout, 1 retry
+	base := time.Now()
+
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 0})
+	p.processStalledTransfersAt(base)
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 0})
+	p.processStalledTransfersAt(base.Add(61 * time.Minute)) // stall -> retry (RetryCount=1)
+	if r, _ := stallCallCounts(client); r != 1 {
+		t.Fatalf("expected one retry, got %d", r)
+	}
+
+	// Byte activity after the retry refreshes the window but must keep RetryCount.
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 100})
+	p.processStalledTransfersAt(base.Add(70 * time.Minute))
+	st := getStallStateForTest(t, p, 1)
+	if st.RetryCount != 1 || !st.StatusSince.Equal(base.Add(70*time.Minute)) {
+		t.Fatalf("activity should refresh window but keep budget: RetryCount=%d StatusSince=%v", st.RetryCount, st.StatusSince)
+	}
+
+	// Freeze again past the refreshed window: budget is spent -> delete.
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING", Downloaded: 100})
+	p.processStalledTransfersAt(base.Add(131 * time.Minute))
+	if r, d := stallCallCounts(client); r != 1 || d != 1 {
+		t.Fatalf("want retries=1 deletes=1, got retries=%d deletes=%d", r, d)
+	}
+}
+
+func TestProcessStalledTransfersIgnoresTerminalStatuses(t *testing.T) {
+	client := &fakePutioClient{}
+	p := newTestManagerWithClient(client).processor
+	base := time.Now()
+
+	for _, status := range []string{"COMPLETED", "SEEDING", "ERROR", "COMPLETING"} {
+		setPutioTransfers(p, &putio.Transfer{ID: 1, Status: status})
+		p.processStalledTransfersAt(base)
+		p.processStalledTransfersAt(base.Add(2 * time.Hour))
+	}
+	if r, d := stallCallCounts(client); r != 0 || d != 0 {
+		t.Fatalf("terminal/COMPLETING statuses must be ignored, got retries=%d deletes=%d", r, d)
+	}
+	if _, ok := p.stallStates.Load(int64(1)); ok {
+		t.Fatalf("no stall state should exist for terminal statuses")
+	}
+}
+
+func TestProcessStalledTransfersPrunesVanishedEntries(t *testing.T) {
+	client := &fakePutioClient{}
+	p := newTestManagerWithClient(client).processor
+	base := time.Now()
+
+	setPutioTransfers(p, &putio.Transfer{ID: 1, Status: "DOWNLOADING"})
+	p.processStalledTransfersAt(base) // creates the entry
+	getStallStateForTest(t, p, 1)     // precondition: it exists
+
+	// Transfer disappears from the snapshot (completed/purged) -> entry pruned.
+	setPutioTransfers(p)
+	p.processStalledTransfersAt(base.Add(time.Minute))
+	if _, ok := p.stallStates.Load(int64(1)); ok {
+		t.Fatalf("stall state for a vanished transfer should be pruned")
+	}
+}
+
+func TestProcessStalledTransfersToleratesRetryError(t *testing.T) {
+	client := &fakePutioClient{
+		retryTransferFn: func(int64) (*putio.Transfer, error) {
+			return nil, errors.New("boom")
+		},
+	}
+	p := newTestManagerWithClient(client).processor
+	base := time.Now()
+
+	tr := &putio.Transfer{ID: 1, Status: "DOWNLOADING"}
+	setPutioTransfers(p, tr)
+	p.processStalledTransfersAt(base)
+	setPutioTransfers(p, tr)
+	p.processStalledTransfersAt(base.Add(61 * time.Minute))
+
+	if r, d := stallCallCounts(client); r != 1 || d != 0 {
+		t.Fatalf("retry error: want retries=1 deletes=0, got retries=%d deletes=%d", r, d)
+	}
+	if st := getStallStateForTest(t, p, 1); st.RetryCount != 1 {
+		t.Fatalf("RetryCount must advance despite retry error, got %d", st.RetryCount)
+	}
+}
+
 func TestProcessFailedTransfersRequeuesImmediatelyOnFirstFailure(t *testing.T) {
 	client := &fakePutioClient{
 		getAllTransferFilesFn: func(fileID int64) ([]api.TransferFile, error) {

--- a/internal/server/freespace_test.go
+++ b/internal/server/freespace_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/doodla/go-putio"
 	"github.com/doodla/plundrio/internal/config"
@@ -154,5 +155,27 @@ func TestFreeSpaceCacheCollapsesBurst(t *testing.T) {
 	defer client.mu.Unlock()
 	if client.accountInfoCalls != 1 {
 		t.Errorf("expected 1 cached account.info call across a burst, got %d", client.accountInfoCalls)
+	}
+}
+
+func TestFreeSpaceCacheRefreshesAfterTTL(t *testing.T) {
+	client := &fakePutioClient{accountInfo: accountWithAvail(50_000_000_000)}
+	dl := newFakeDownloadService()
+	srv := newTestServerWithMinFree(t, client, dl, "10GB")
+
+	// Drive the cache clock so TTL expiry is deterministic.
+	clock := time.Now()
+	srv.now = func() time.Time { return clock }
+
+	addMagnet(t, srv)                   // cold cache -> fetch #1, stamped at clock
+	clock = clock.Add(30 * time.Second) // still within the 60s TTL
+	addMagnet(t, srv)                   // cached -> no fetch
+	clock = clock.Add(31 * time.Second) // now 61s since the fetch -> stale
+	addMagnet(t, srv)                   // refresh -> fetch #2
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if client.accountInfoCalls != 2 {
+		t.Errorf("expected 2 account.info calls (1 cold + 1 after TTL), got %d", client.accountInfoCalls)
 	}
 }

--- a/internal/server/freespace_test.go
+++ b/internal/server/freespace_test.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/doodla/go-putio"
+	"github.com/doodla/plundrio/internal/config"
+)
+
+var errAccount = errors.New("account info unavailable")
+
+// newTestServerWithMinFree builds a Server like newTestServer but with the
+// opt-in free-space floor configured.
+func newTestServerWithMinFree(t *testing.T, client *fakePutioClient, dl *fakeDownloadService, minFree string) *Server {
+	t.Helper()
+	cfg := &config.Config{
+		TargetDir:    t.TempDir(),
+		FolderID:     42,
+		ListenAddr:   ":0",
+		MinFreeSpace: minFree,
+	}
+	return New(cfg, client, dl)
+}
+
+func accountWithAvail(avail int64) *putio.AccountInfo {
+	ai := &putio.AccountInfo{Username: "test"}
+	ai.Disk.Avail = avail
+	return ai
+}
+
+func addMagnet(t *testing.T, srv *Server) rpcResponse {
+	t.Helper()
+	req := rpcRequest(t, "torrent-add", map[string]interface{}{
+		"magnetLink": "magnet:?xt=urn:btih:abc",
+	})
+	w := httptest.NewRecorder()
+	srv.handleRPC(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected HTTP 200 envelope, got %d, body=%s", w.Code, w.Body.String())
+	}
+	return decodeRPCResponse(t, w.Body.Bytes())
+}
+
+func TestTorrentAddRejectedBelowFreeSpaceFloor(t *testing.T) {
+	client := &fakePutioClient{accountInfo: accountWithAvail(5_000_000_000)} // 5GB avail
+	dl := newFakeDownloadService()
+	srv := newTestServerWithMinFree(t, client, dl, "10GB")
+
+	resp := addMagnet(t, srv)
+	if resp.Result == "success" {
+		t.Fatalf("expected rejection below floor, got success")
+	}
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.addTransferCalls) != 0 {
+		t.Errorf("AddTransfer must not run when below the free-space floor; got %d calls", len(client.addTransferCalls))
+	}
+}
+
+func TestTorrentAddMetainfoRejectedBelowFreeSpaceFloor(t *testing.T) {
+	// The floor must apply to the .torrent/metainfo path too, not just magnets.
+	client := &fakePutioClient{accountInfo: accountWithAvail(5_000_000_000)} // 5GB
+	dl := newFakeDownloadService()
+	srv := newTestServerWithMinFree(t, client, dl, "10GB")
+
+	req := rpcRequest(t, "torrent-add", map[string]interface{}{
+		"filename": "ubuntu.torrent",
+		"metainfo": base64.StdEncoding.EncodeToString([]byte("d8:announce15:http://example.come")),
+	})
+	w := httptest.NewRecorder()
+	srv.handleRPC(w, req)
+
+	resp := decodeRPCResponse(t, w.Body.Bytes())
+	if resp.Result == "success" {
+		t.Fatalf("expected rejection below floor on metainfo path, got success")
+	}
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.uploadFileCalls) != 0 {
+		t.Errorf("UploadFile must not run when below the free-space floor; got %d calls", len(client.uploadFileCalls))
+	}
+}
+
+func TestTorrentAddAllowedAboveFreeSpaceFloor(t *testing.T) {
+	client := &fakePutioClient{accountInfo: accountWithAvail(50_000_000_000)} // 50GB avail
+	dl := newFakeDownloadService()
+	srv := newTestServerWithMinFree(t, client, dl, "10GB")
+
+	resp := addMagnet(t, srv)
+	if resp.Result != "success" {
+		t.Fatalf("expected success above floor, got %q", resp.Result)
+	}
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.addTransferCalls) != 1 {
+		t.Errorf("AddTransfer calls = %d, want 1", len(client.addTransferCalls))
+	}
+}
+
+func TestTorrentAddFreeSpaceCheckDisabledByDefault(t *testing.T) {
+	// Tiny avail, but no floor configured: add proceeds and account info is
+	// never even fetched.
+	client := &fakePutioClient{accountInfo: accountWithAvail(1)}
+	dl := newFakeDownloadService()
+	srv := newTestServerWithMinFree(t, client, dl, "")
+
+	resp := addMagnet(t, srv)
+	if resp.Result != "success" {
+		t.Fatalf("expected success with check disabled, got %q", resp.Result)
+	}
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if client.accountInfoCalls != 0 {
+		t.Errorf("GetAccountInfo should not be called when check is disabled; got %d", client.accountInfoCalls)
+	}
+	if len(client.addTransferCalls) != 1 {
+		t.Errorf("AddTransfer calls = %d, want 1", len(client.addTransferCalls))
+	}
+}
+
+func TestTorrentAddFreeSpaceFailsOpenOnAccountError(t *testing.T) {
+	// Floor configured, but the account lookup errors: the add must proceed
+	// (fail open) rather than block downloads on a transient API hiccup.
+	client := &fakePutioClient{getAccountInfoErr: errAccount}
+	dl := newFakeDownloadService()
+	srv := newTestServerWithMinFree(t, client, dl, "10GB")
+
+	resp := addMagnet(t, srv)
+	if resp.Result != "success" {
+		t.Fatalf("expected fail-open success on account error, got %q", resp.Result)
+	}
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.addTransferCalls) != 1 {
+		t.Errorf("AddTransfer calls = %d, want 1 (fail open)", len(client.addTransferCalls))
+	}
+}
+
+func TestFreeSpaceCacheCollapsesBurst(t *testing.T) {
+	client := &fakePutioClient{accountInfo: accountWithAvail(50_000_000_000)}
+	dl := newFakeDownloadService()
+	srv := newTestServerWithMinFree(t, client, dl, "10GB")
+
+	for i := 0; i < 3; i++ {
+		if resp := addMagnet(t, srv); resp.Result != "success" {
+			t.Fatalf("add %d: expected success, got %q", i, resp.Result)
+		}
+	}
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if client.accountInfoCalls != 1 {
+		t.Errorf("expected 1 cached account.info call across a burst, got %d", client.accountInfoCalls)
+	}
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -48,6 +48,12 @@ type fakePutioClient struct {
 	deleteFileErr     error
 	deleteTransferErr error
 	getTransfersErr   error
+
+	// accountInfo / getAccountInfoErr drive GetAccountInfo; accountInfoCalls
+	// counts invocations so tests can assert the 60s cache collapses bursts.
+	accountInfo       *putio.AccountInfo
+	getAccountInfoErr error
+	accountInfoCalls  int
 }
 
 type uploadFileCall struct {
@@ -62,6 +68,15 @@ type addTransferCall struct {
 }
 
 func (f *fakePutioClient) GetAccountInfo(ctx context.Context) (*putio.AccountInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.accountInfoCalls++
+	if f.getAccountInfoErr != nil {
+		return nil, f.getAccountInfoErr
+	}
+	if f.accountInfo != nil {
+		return f.accountInfo, nil
+	}
 	return &putio.AccountInfo{Username: "test"}, nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,6 +66,10 @@ type Server struct {
 	accountMu       sync.Mutex
 	cachedAccount   *putio.AccountInfo
 	cachedAccountAt time.Time
+
+	// now is the clock used for cache freshness; time.Now in production,
+	// overridden in tests to drive TTL expiry deterministically.
+	now func() time.Time
 }
 
 // New creates a new RPC server
@@ -88,6 +92,7 @@ func New(cfg *config.Config, client PutioClient, dlService DownloadService) *Ser
 		dlService:    dlService,
 		quotaTicker:  time.NewTicker(15 * time.Minute),
 		minFreeSpace: minFree,
+		now:          time.Now,
 	}
 }
 
@@ -97,7 +102,7 @@ func (s *Server) cachedAccountInfo(ctx context.Context) (*putio.AccountInfo, err
 	s.accountMu.Lock()
 	defer s.accountMu.Unlock()
 
-	if s.cachedAccount != nil && time.Since(s.cachedAccountAt) < accountCacheTTL {
+	if s.cachedAccount != nil && s.now().Sub(s.cachedAccountAt) < accountCacheTTL {
 		return s.cachedAccount, nil
 	}
 	account, err := s.client.GetAccountInfo(ctx)
@@ -105,7 +110,7 @@ func (s *Server) cachedAccountInfo(ctx context.Context) (*putio.AccountInfo, err
 		return nil, err
 	}
 	s.cachedAccount = account
-	s.cachedAccountAt = time.Now()
+	s.cachedAccountAt = s.now()
 	return account, nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -11,6 +13,13 @@ import (
 	"github.com/doodla/plundrio/internal/download"
 	"github.com/doodla/plundrio/internal/log"
 )
+
+// accountCacheTTL bounds how stale the cached AccountInfo used by the
+// torrent-add free-space check may be. A burst of grabs from *arr would
+// otherwise fire one account.info call per add; 60s collapses that to at most
+// one call per minute while keeping the free-space figure fresh enough for a
+// floor check.
+const accountCacheTTL = 60 * time.Second
 
 // PutioClient abstracts the put.io API methods used by the RPC server.
 type PutioClient interface {
@@ -46,17 +55,82 @@ type Server struct {
 	stopChan     chan struct{}
 	dlService    DownloadService
 	quotaWarning atomic.Bool // tracks if we've already warned about quota
+
+	// minFreeSpace is cfg.MinFreeSpace parsed to bytes once at construction.
+	// 0 disables the torrent-add free-space check.
+	minFreeSpace int64
+
+	// accountMu guards the cached AccountInfo used by the free-space check.
+	// Refreshes happen under the lock (single-flight): a burst of concurrent
+	// adds blocks on at most one account.info fetch per accountCacheTTL.
+	accountMu       sync.Mutex
+	cachedAccount   *putio.AccountInfo
+	cachedAccountAt time.Time
 }
 
 // New creates a new RPC server
 func New(cfg *config.Config, client PutioClient, dlService DownloadService) *Server {
-	return &Server{
-		cfg:         cfg,
-		client:      client,
-		stopChan:    make(chan struct{}),
-		dlService:   dlService,
-		quotaTicker: time.NewTicker(15 * time.Minute),
+	// cfg.MinFreeSpace is validated at startup (cmd/plundrio), so a parse error
+	// here is not expected; fail open (disable the floor) and warn rather than
+	// block all adds on a bad value that slipped through.
+	minFree, err := config.ParseByteSize(cfg.MinFreeSpace)
+	if err != nil {
+		log.Warn("server").
+			Str("min_free_space", cfg.MinFreeSpace).
+			Err(err).
+			Msg("Invalid min_free_space; disabling free-space check")
+		minFree = 0
 	}
+	return &Server{
+		cfg:          cfg,
+		client:       client,
+		stopChan:     make(chan struct{}),
+		dlService:    dlService,
+		quotaTicker:  time.NewTicker(15 * time.Minute),
+		minFreeSpace: minFree,
+	}
+}
+
+// cachedAccountInfo returns put.io AccountInfo no older than accountCacheTTL,
+// fetching a fresh copy under accountMu when the cache is cold or stale.
+func (s *Server) cachedAccountInfo(ctx context.Context) (*putio.AccountInfo, error) {
+	s.accountMu.Lock()
+	defer s.accountMu.Unlock()
+
+	if s.cachedAccount != nil && time.Since(s.cachedAccountAt) < accountCacheTTL {
+		return s.cachedAccount, nil
+	}
+	account, err := s.client.GetAccountInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.cachedAccount = account
+	s.cachedAccountAt = time.Now()
+	return account, nil
+}
+
+// ensureFreeSpace rejects an add when put.io free space is below the configured
+// floor. Disabled when minFreeSpace == 0. Fails OPEN: a put.io lookup error logs
+// a warning and returns nil so a transient API hiccup never blocks downloads.
+func (s *Server) ensureFreeSpace(ctx context.Context) error {
+	if s.minFreeSpace <= 0 {
+		return nil
+	}
+	account, err := s.cachedAccountInfo(ctx)
+	if err != nil {
+		log.Warn("server").
+			Err(err).
+			Msg("Free-space check skipped: could not fetch put.io account info")
+		return nil
+	}
+	if account.Disk.Avail < s.minFreeSpace {
+		log.Warn("server").
+			Int64("avail_bytes", account.Disk.Avail).
+			Int64("min_free_bytes", s.minFreeSpace).
+			Msg("Rejecting torrent-add: put.io free space below configured floor")
+		return fmt.Errorf("put.io free space %d bytes is below the configured minimum of %d bytes", account.Disk.Avail, s.minFreeSpace)
+	}
+	return nil
 }
 
 // Start begins listening for RPC requests

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -149,8 +149,10 @@ func (s *Server) Start() error {
 		Handler: mux,
 	}
 
-	// Get and log account info
-	account, err := s.client.GetAccountInfo(context.Background())
+	// Get and log account info. Goes through the cache so the immediately
+	// following checkDiskQuota (and the first torrent-add) reuse this fetch
+	// instead of each issuing their own account.info call.
+	account, err := s.cachedAccountInfo(context.Background())
 	if err != nil {
 		log.Warn("server").Err(err).Msg("Failed to get account info")
 	} else {

--- a/internal/server/torrent.go
+++ b/internal/server/torrent.go
@@ -77,6 +77,12 @@ func (s *Server) handleTorrentAdd(ctx context.Context, args json.RawMessage) (in
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
 
+	// Reject before consuming put.io space when free space is below the floor.
+	// Applies to both .torrent uploads and magnets. No-op unless configured.
+	if err := s.ensureFreeSpace(ctx); err != nil {
+		return nil, err
+	}
+
 	category := extractCategory(s.cfg.TargetDir, params.DownloadDir)
 	var name string
 	var hash string

--- a/internal/server/utils.go
+++ b/internal/server/utils.go
@@ -9,7 +9,7 @@ import (
 
 // checkDiskQuota checks disk usage and handles quota warnings
 func (s *Server) checkDiskQuota() (bool, error) {
-	account, err := s.client.GetAccountInfo(context.Background())
+	account, err := s.cachedAccountInfo(context.Background())
 	if err != nil {
 		return false, fmt.Errorf("failed to check disk quota: %w", err)
 	}


### PR DESCRIPTION
The put.io JSON API path had no rate-limit awareness: the SDK collapses
every non-2xx into a generic error and ignores Retry-After/X-RateLimit-*
headers, and the monitor loop just logged and dropped the tick. Under
throttling plundrio neither backed off nor surfaced the cause (the only
429 handling was a string match on grab CDN errors — the file path, not
the API path).

Centralize 429 handling in internal/api so every client call benefits:

- New internal/api/ratelimit.go: isRateLimited (errors.As on the SDK's
  *putio.ErrorResponse, mirroring download.isNotFoundError),
  retryAfterFromHeader (RFC-7231 seconds-or-HTTP-date), backoffDelay
  (exponential + full jitter, capped, honoring Retry-After), and the
  withRateLimitRetry wrapper.
- Wrap every network method on Client. A test-injectable sleeper seam
  keeps backoff near-instant in tests. Backoff respects ctx cancellation
  so Stop() aborts promptly; rlMaxRetries=3 bounds the worst-case monitor
  stall. 404 (orphan-recovery) and other non-429 errors pass through
  unchanged, preserving the %w chain.
- Throttling is now logged (Warn per backoff, Error on exhaustion) so the
  operator sees the cause instead of a silent dropped tick.

H2: the 1s poll is demo-only (production already polls at 30s by design),
so there is no live prod bug. Add a validated --transfer-check-interval
flag instead — it rejects sub-5s intervals outside demo mode, closing the
door on an operator re-creating the rate-limit problem by hand.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XH67uj6AKh6PtBBbDPNTWy