### PR TITLE
feat(server): surface put.io error messages as Transmission errorString (#22)

### DIFF
--- a/internal/dashboard/render.go
+++ b/internal/dashboard/render.go
@@ -101,12 +101,13 @@ func renderTransfer(t *putio.Transfer, ctx *download.TransferContext, category s
 		dto.LifecycleState = "None"
 	}
 
-	// Error precedence (copy torrent.go:handleTorrentGet): plundrio's permanent
-	// failure string wins over put.io's ErrorMessage. error_string =
-	// prog.Error if the cascade marked it permanent, else put.io's ErrorMessage.
-	// A transient Failed (still retrying) reports error:false and stays
+	// Error precedence (shared with torrent.go:handleTorrentGet via
+	// transferprog): plundrio's permanent failure string wins over put.io's own
+	// error fields. error_string = prog.Error if the cascade marked it
+	// permanent, else put.io's synthesized reason (tracker/error/status). A
+	// transient Failed (still retrying) reports error:false and stays
 	// mid-progress, identical to the RPC path.
-	errString := t.ErrorMessage
+	errString := transferprog.PutioErrorString(t)
 	if prog.Error != "" {
 		errString = prog.Error
 	}

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -145,14 +145,10 @@ func isTransientError(err error) bool {
 		}
 	}
 
-	// Retryable HTTP status codes from grab's response error.
-	for _, code := range []string{"429", "502", "503", "504"} {
-		if strings.Contains(msg, code) {
-			return true
-		}
-	}
-
-	return false
+	// Retryable HTTP status codes from grab's CDN response or put.io's
+	// GetDownloadURL, matched on the typed errors rather than substrings (see
+	// retryableHTTPStatus).
+	return retryableHTTPStatus(err)
 }
 
 // downloadFile downloads a file from Put.io to the target directory using grab

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -4,9 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"syscall"
 	"testing"
+
+	grab "github.com/cavaliergopher/grab/v3"
 )
 
 func TestIsTransientError(t *testing.T) {
@@ -31,15 +34,33 @@ func TestIsTransientError(t *testing.T) {
 		{name: "nil_error", err: nil, want: false},
 		{name: "download_cancelled_error", err: NewDownloadCancelledError("test.mkv", "shutdown"), want: false},
 
-		// Bare-string errors continue to be classified correctly.
+		// Bare-string network errors continue to be classified correctly.
 		{name: "connection_reset", err: errors.New("connection reset"), want: true},
 		{name: "connection_refused", err: errors.New("connection refused"), want: true},
 		{name: "io_timeout", err: errors.New("i/o timeout"), want: true},
-		{name: "http_429_too_many_requests", err: errors.New("HTTP 429 Too Many Requests"), want: true},
-		{name: "server_returned_503", err: errors.New("server returned 503"), want: true},
-		{name: "bad_gateway_502", err: errors.New("bad gateway 502"), want: true},
-		{name: "gateway_timeout_504", err: errors.New("gateway timeout 504"), want: true},
 		{name: "random_non_transient_error", err: errors.New("some random error"), want: false},
+
+		// Retryable HTTP status codes are matched on grab's typed
+		// StatusCodeError (the real CDN download error shape), not by
+		// substring-scanning the message.
+		{name: "grab_429", err: grab.StatusCodeError(http.StatusTooManyRequests), want: true},
+		{name: "grab_502", err: grab.StatusCodeError(http.StatusBadGateway), want: true},
+		{name: "grab_503", err: grab.StatusCodeError(http.StatusServiceUnavailable), want: true},
+		{name: "grab_504", err: grab.StatusCodeError(http.StatusGatewayTimeout), want: true},
+		{name: "grab_404_not_retryable", err: grab.StatusCodeError(http.StatusNotFound), want: false},
+		{
+			name: "grab_503_wrapped",
+			err:  fmt.Errorf("download failed: %w", grab.StatusCodeError(http.StatusServiceUnavailable)),
+			want: true,
+		},
+		// put.io API 5xx from GetDownloadURL reaches the same retry path.
+		{name: "putio_503", err: putioErrorWith("get download url", http.StatusServiceUnavailable), want: true},
+		{name: "putio_500_not_retryable", err: putioErrorWith("get download url", http.StatusInternalServerError), want: false},
+
+		// A bare-string error that merely contains "429"/"502" is NO longer
+		// treated as transient — only the typed status errors above are. This
+		// guards against false positives from URLs or byte counts.
+		{name: "bare_string_with_429_not_transient", err: errors.New("downloaded 4294967296 bytes"), want: false},
 
 		// Wrapped messages — the original classifier failed these.
 		{

--- a/internal/download/errors.go
+++ b/internal/download/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	grab "github.com/cavaliergopher/grab/v3"
 	"github.com/doodla/go-putio"
 )
 
@@ -52,4 +53,33 @@ func isNotFoundError(err error) bool {
 		return false
 	}
 	return putioErr.Response.StatusCode == http.StatusNotFound
+}
+
+// retryableHTTPStatus reports whether err carries an HTTP status that warrants
+// a download retry. Two typed error sources reach the download retry path:
+// grab's StatusCodeError (the CDN file fetch) and put.io's ErrorResponse
+// (GetDownloadURL). Matching the typed errors via errors.As — rather than
+// substring-scanning the message for "429"/"502"/… — avoids false positives
+// from a URL or byte count that merely contains those digits.
+func retryableHTTPStatus(err error) bool {
+	var code int
+	var grabErr grab.StatusCodeError
+	if errors.As(err, &grabErr) {
+		code = int(grabErr)
+	} else {
+		var putioErr *putio.ErrorResponse
+		if !errors.As(err, &putioErr) || putioErr.Response == nil {
+			return false
+		}
+		code = putioErr.Response.StatusCode
+	}
+	switch code {
+	case http.StatusTooManyRequests, // 429
+		http.StatusBadGateway,         // 502
+		http.StatusServiceUnavailable, // 503
+		http.StatusGatewayTimeout:     // 504
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/server/torrent.go
+++ b/internal/server/torrent.go
@@ -155,6 +155,43 @@ func (s *Server) handleTorrentAdd(ctx context.Context, args json.RawMessage) (in
 	}, nil
 }
 
+// putioErrorString synthesizes a human-readable failure reason for *arr from a
+// put.io transfer's error fields, so a DMCA takedown / dead torrent / tracker
+// ban surfaces as Transmission's errorString instead of a silent "stopped"
+// (see #22). Without this, Sonarr/Radarr only notice via missing episodes.
+//
+// Field handling differs by how trustworthy each field is as an error signal:
+//
+//   - ErrorMessage is only populated when put.io errors a transfer, so it is
+//     always safe to surface.
+//   - TrackerMessage and StatusMessage are freeform and carry benign text in
+//     healthy states (tracker announce stats, "getting metadata", ...), so they
+//     are only consulted once put.io has actually marked the transfer ERROR —
+//     otherwise we'd flip error=true on a working transfer.
+//
+// When status is ERROR the distinct messages are joined in precedence order
+// (tracker > error > status): the tracker message (e.g. a DMCA notice or
+// "torrent not found") is the most actionable, then put.io's own ErrorMessage,
+// then its freeform StatusMessage. De-duping avoids repeating a reason put.io
+// copies across fields.
+func putioErrorString(t *putio.Transfer) string {
+	if t.Status != "ERROR" {
+		return t.ErrorMessage
+	}
+
+	seen := make(map[string]bool, 3)
+	var parts []string
+	for _, m := range []string{t.TrackerMessage, t.ErrorMessage, t.StatusMessage} {
+		m = strings.TrimSpace(m)
+		if m == "" || seen[m] {
+			continue
+		}
+		seen[m] = true
+		parts = append(parts, m)
+	}
+	return strings.Join(parts, "; ")
+}
+
 // handleTorrentGet processes torrent-get requests
 func (s *Server) handleTorrentGet(_ context.Context, args json.RawMessage) (interface{}, error) {
 	var params struct {
@@ -223,10 +260,10 @@ func (s *Server) handleTorrentGet(_ context.Context, args json.RawMessage) (inte
 		rateDownload := t.DownloadSpeed
 
 		// Pick the error to report. plundrio's permanently-failed cascade wins
-		// over put.io's ErrorMessage: if both are set, plundrio's reflects the
+		// over put.io's error fields: if both are set, plundrio's reflects the
 		// terminal decision (we already gave up retrying), and that's the one
 		// *arr should act on.
-		errString := t.ErrorMessage
+		errString := putioErrorString(t)
 		if prog.Error != "" {
 			errString = prog.Error
 		}

--- a/internal/server/torrent.go
+++ b/internal/server/torrent.go
@@ -13,6 +13,7 @@ import (
 	"github.com/doodla/go-putio"
 	"github.com/doodla/plundrio/internal/download"
 	"github.com/doodla/plundrio/internal/log"
+	"github.com/doodla/plundrio/internal/transferprog"
 )
 
 // extractCategory returns the relative category path from downloadDir.
@@ -155,43 +156,6 @@ func (s *Server) handleTorrentAdd(ctx context.Context, args json.RawMessage) (in
 	}, nil
 }
 
-// putioErrorString synthesizes a human-readable failure reason for *arr from a
-// put.io transfer's error fields, so a DMCA takedown / dead torrent / tracker
-// ban surfaces as Transmission's errorString instead of a silent "stopped"
-// (see #22). Without this, Sonarr/Radarr only notice via missing episodes.
-//
-// Field handling differs by how trustworthy each field is as an error signal:
-//
-//   - ErrorMessage is only populated when put.io errors a transfer, so it is
-//     always safe to surface.
-//   - TrackerMessage and StatusMessage are freeform and carry benign text in
-//     healthy states (tracker announce stats, "getting metadata", ...), so they
-//     are only consulted once put.io has actually marked the transfer ERROR —
-//     otherwise we'd flip error=true on a working transfer.
-//
-// When status is ERROR the distinct messages are joined in precedence order
-// (tracker > error > status): the tracker message (e.g. a DMCA notice or
-// "torrent not found") is the most actionable, then put.io's own ErrorMessage,
-// then its freeform StatusMessage. De-duping avoids repeating a reason put.io
-// copies across fields.
-func putioErrorString(t *putio.Transfer) string {
-	if t.Status != "ERROR" {
-		return t.ErrorMessage
-	}
-
-	seen := make(map[string]bool, 3)
-	var parts []string
-	for _, m := range []string{t.TrackerMessage, t.ErrorMessage, t.StatusMessage} {
-		m = strings.TrimSpace(m)
-		if m == "" || seen[m] {
-			continue
-		}
-		seen[m] = true
-		parts = append(parts, m)
-	}
-	return strings.Join(parts, "; ")
-}
-
 // handleTorrentGet processes torrent-get requests
 func (s *Server) handleTorrentGet(_ context.Context, args json.RawMessage) (interface{}, error) {
 	var params struct {
@@ -263,7 +227,7 @@ func (s *Server) handleTorrentGet(_ context.Context, args json.RawMessage) (inte
 		// over put.io's error fields: if both are set, plundrio's reflects the
 		// terminal decision (we already gave up retrying), and that's the one
 		// *arr should act on.
-		errString := putioErrorString(t)
+		errString := transferprog.PutioErrorString(t)
 		if prog.Error != "" {
 			errString = prog.Error
 		}

--- a/internal/server/torrent_test.go
+++ b/internal/server/torrent_test.go
@@ -4,7 +4,62 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/doodla/go-putio"
 )
+
+func TestPutioErrorString(t *testing.T) {
+	tests := []struct {
+		name     string
+		transfer putio.Transfer
+		want     string
+	}{
+		{
+			name:     "non-error status ignores tracker and status messages",
+			transfer: putio.Transfer{Status: "DOWNLOADING", TrackerMessage: "1 seeders 2 leechers", StatusMessage: "getting metadata"},
+			want:     "",
+		},
+		{
+			name:     "non-error status still surfaces ErrorMessage if set",
+			transfer: putio.Transfer{Status: "DOWNLOADING", ErrorMessage: "leftover error"},
+			want:     "leftover error",
+		},
+		{
+			name:     "error with tracker message only",
+			transfer: putio.Transfer{Status: "ERROR", TrackerMessage: "torrent not found"},
+			want:     "torrent not found",
+		},
+		{
+			name:     "error precedence tracker then error then status",
+			transfer: putio.Transfer{Status: "ERROR", TrackerMessage: "DMCA notice", ErrorMessage: "download failed", StatusMessage: "no peers"},
+			want:     "DMCA notice; download failed; no peers",
+		},
+		{
+			name:     "error de-dups repeated message across fields",
+			transfer: putio.Transfer{Status: "ERROR", ErrorMessage: "dead torrent", StatusMessage: "dead torrent"},
+			want:     "dead torrent",
+		},
+		{
+			name:     "error trims whitespace and skips blank fields",
+			transfer: putio.Transfer{Status: "ERROR", TrackerMessage: "  ", ErrorMessage: " banned ", StatusMessage: ""},
+			want:     "banned",
+		},
+		{
+			name:     "error with no messages yields empty",
+			transfer: putio.Transfer{Status: "ERROR"},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := putioErrorString(&tt.transfer)
+			if got != tt.want {
+				t.Errorf("putioErrorString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestDeleteLocalData(t *testing.T) {
 	tests := []struct {

--- a/internal/server/torrent_test.go
+++ b/internal/server/torrent_test.go
@@ -4,62 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/doodla/go-putio"
 )
-
-func TestPutioErrorString(t *testing.T) {
-	tests := []struct {
-		name     string
-		transfer putio.Transfer
-		want     string
-	}{
-		{
-			name:     "non-error status ignores tracker and status messages",
-			transfer: putio.Transfer{Status: "DOWNLOADING", TrackerMessage: "1 seeders 2 leechers", StatusMessage: "getting metadata"},
-			want:     "",
-		},
-		{
-			name:     "non-error status still surfaces ErrorMessage if set",
-			transfer: putio.Transfer{Status: "DOWNLOADING", ErrorMessage: "leftover error"},
-			want:     "leftover error",
-		},
-		{
-			name:     "error with tracker message only",
-			transfer: putio.Transfer{Status: "ERROR", TrackerMessage: "torrent not found"},
-			want:     "torrent not found",
-		},
-		{
-			name:     "error precedence tracker then error then status",
-			transfer: putio.Transfer{Status: "ERROR", TrackerMessage: "DMCA notice", ErrorMessage: "download failed", StatusMessage: "no peers"},
-			want:     "DMCA notice; download failed; no peers",
-		},
-		{
-			name:     "error de-dups repeated message across fields",
-			transfer: putio.Transfer{Status: "ERROR", ErrorMessage: "dead torrent", StatusMessage: "dead torrent"},
-			want:     "dead torrent",
-		},
-		{
-			name:     "error trims whitespace and skips blank fields",
-			transfer: putio.Transfer{Status: "ERROR", TrackerMessage: "  ", ErrorMessage: " banned ", StatusMessage: ""},
-			want:     "banned",
-		},
-		{
-			name:     "error with no messages yields empty",
-			transfer: putio.Transfer{Status: "ERROR"},
-			want:     "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := putioErrorString(&tt.transfer)
-			if got != tt.want {
-				t.Errorf("putioErrorString() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestDeleteLocalData(t *testing.T) {
 	tests := []struct {

--- a/internal/transferprog/transferprog.go
+++ b/internal/transferprog/transferprog.go
@@ -13,8 +13,10 @@
 package transferprog
 
 import (
+	"strings"
 	"time"
 
+	"github.com/doodla/go-putio"
 	"github.com/doodla/plundrio/internal/download"
 )
 
@@ -156,6 +158,50 @@ func calculateProgressWithContext(in Input) Result {
 	}
 
 	return result
+}
+
+// PutioErrorString synthesizes a human-readable failure reason from a put.io
+// transfer's error fields, shared by the RPC server (Transmission errorString)
+// and the dashboard (error_string) so both faces report the same reason. When
+// put.io marks a transfer ERROR (DMCA takedown, dead torrent, tracker ban), the
+// reason lives in tracker_message / error_message / status_message; without
+// surfacing it Sonarr/Radarr only see a generic "stopped" and silently drop the
+// grab (see #22).
+//
+// Field handling differs by how trustworthy each field is as an error signal:
+//
+//   - ErrorMessage is only populated when put.io errors a transfer, so it is
+//     always safe to surface.
+//   - TrackerMessage and StatusMessage are freeform and carry benign text in
+//     healthy states (tracker announce stats, "getting metadata", ...), so they
+//     are only consulted once put.io has actually marked the transfer ERROR —
+//     otherwise we'd flip error=true on a working transfer.
+//
+// In the ERROR state the distinct messages are joined in precedence order
+// (tracker > error > status): the tracker message (e.g. a DMCA notice or
+// "torrent not found") is the most actionable, then put.io's own ErrorMessage,
+// then its freeform StatusMessage. De-duping avoids repeating a reason put.io
+// copies across fields.
+//
+// Note this is put.io's own error reason. plundrio's permanent-failure cascade
+// (Result.Error) still takes precedence at the call sites when set, because it
+// reflects the terminal local decision *arr should act on.
+func PutioErrorString(t *putio.Transfer) string {
+	if t.Status != "ERROR" {
+		return t.ErrorMessage
+	}
+
+	seen := make(map[string]bool, 3)
+	var parts []string
+	for _, m := range []string{t.TrackerMessage, t.ErrorMessage, t.StatusMessage} {
+		m = strings.TrimSpace(m)
+		if m == "" || seen[m] {
+			continue
+		}
+		seen[m] = true
+		parts = append(parts, m)
+	}
+	return strings.Join(parts, "; ")
 }
 
 // MapPutioStatusValue maps a Put.io transfer status string to a Transmission status code.

--- a/internal/transferprog/transferprog_test.go
+++ b/internal/transferprog/transferprog_test.go
@@ -4,8 +4,62 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/doodla/go-putio"
 	"github.com/doodla/plundrio/internal/download"
 )
+
+func TestPutioErrorString(t *testing.T) {
+	tests := []struct {
+		name     string
+		transfer putio.Transfer
+		want     string
+	}{
+		{
+			name:     "non-error status ignores tracker and status messages",
+			transfer: putio.Transfer{Status: "DOWNLOADING", TrackerMessage: "1 seeders 2 leechers", StatusMessage: "getting metadata"},
+			want:     "",
+		},
+		{
+			name:     "non-error status still surfaces ErrorMessage if set",
+			transfer: putio.Transfer{Status: "DOWNLOADING", ErrorMessage: "leftover error"},
+			want:     "leftover error",
+		},
+		{
+			name:     "error with tracker message only",
+			transfer: putio.Transfer{Status: "ERROR", TrackerMessage: "torrent not found"},
+			want:     "torrent not found",
+		},
+		{
+			name:     "error precedence tracker then error then status",
+			transfer: putio.Transfer{Status: "ERROR", TrackerMessage: "DMCA notice", ErrorMessage: "download failed", StatusMessage: "no peers"},
+			want:     "DMCA notice; download failed; no peers",
+		},
+		{
+			name:     "error de-dups repeated message across fields",
+			transfer: putio.Transfer{Status: "ERROR", ErrorMessage: "dead torrent", StatusMessage: "dead torrent"},
+			want:     "dead torrent",
+		},
+		{
+			name:     "error trims whitespace and skips blank fields",
+			transfer: putio.Transfer{Status: "ERROR", TrackerMessage: "  ", ErrorMessage: " banned ", StatusMessage: ""},
+			want:     "banned",
+		},
+		{
+			name:     "error with no messages yields empty",
+			transfer: putio.Transfer{Status: "ERROR"},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PutioErrorString(&tt.transfer)
+			if got != tt.want {
+				t.Errorf("PutioErrorString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 // newTestTransferCtx creates a TransferContext for testing with the given parameters.
 func newTestTransferCtx(state download.TransferLifecycleState, totalFiles int32, completedFiles int32, totalSize int64, downloadedSize int64) *download.TransferContext {


### PR DESCRIPTION
When put.io marks a transfer ERROR (DMCA takedown, dead torrent, tracker
ban), the human-readable reason lives in Transfer.tracker_message,
error_message, and status_message. Previously only error_message was
mapped to the Transmission errorString, so Sonarr/Radarr saw a generic
"stopped" state with no reason and silently dropped the grab — the
operator only noticed via missing episodes.

Add putioErrorString, which joins the distinct error fields in precedence
order (tracker > error > status) when status is ERROR. The freeform
tracker/status messages are only consulted in the ERROR state, since they
carry benign text (announce stats, "getting metadata") in healthy states
and would otherwise flip error=true on a working transfer. plundrio's
permanent-failure cascade still wins over put.io's fields when set.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RSnHoUgvdCnFkjsYyKQmqv