### PR TITLE
Hardening pass: graceful shutdown, atomic/race-safe persistence, perf, and test backfill

### DIFF
--- a/cmd/plundrio/config_test.go
+++ b/cmd/plundrio/config_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/doodla/plundrio/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -173,6 +175,65 @@ log_level: debug
 	}
 	if logLevel != "debug" {
 		t.Errorf("log level = %q, want debug", logLevel)
+	}
+}
+
+// TestSampleConfigLoads asserts the YAML emitted by `generate-config` is valid
+// and decodes cleanly through loadConfig.
+func TestSampleConfigLoads(t *testing.T) {
+	resetEnvAndViper(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "plundrio.yaml")
+	if err := os.WriteFile(cfgPath, []byte(sampleConfig), 0o600); err != nil {
+		t.Fatalf("write sample config: %v", err)
+	}
+
+	cmd := newTestRunCmd()
+	if err := cmd.ParseFlags([]string{"--config", cfgPath}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	cfg, logLevel, err := loadConfig(cmd)
+	if err != nil {
+		t.Fatalf("loadConfig on sample: %v", err)
+	}
+	if cfg.PutioFolder != "plundrio" {
+		t.Errorf("PutioFolder = %q, want plundrio", cfg.PutioFolder)
+	}
+	if logLevel != "info" {
+		t.Errorf("log level = %q, want info", logLevel)
+	}
+}
+
+// TestSampleConfigKeysMapToConfigFields parses the sample YAML on its own (no
+// flag-default merge to mask a typo) and asserts every top-level key
+// corresponds to a config.Config mapstructure tag. A key renamed on Config, or
+// a typo in the sample, fails here — the documented sample can't silently drift
+// from the struct it's supposed to mirror.
+func TestSampleConfigKeysMapToConfigFields(t *testing.T) {
+	// Known mapstructure tags on config.Config (skipping "-"), plus log_level:
+	// it's a documented sample key but not a Config field — loadConfig returns
+	// the resolved log level separately (see its doc comment).
+	known := map[string]bool{"log_level": true}
+	ct := reflect.TypeOf(config.Config{})
+	for i := 0; i < ct.NumField(); i++ {
+		tag := ct.Field(i).Tag.Get("mapstructure")
+		if tag != "" && tag != "-" {
+			known[tag] = true
+		}
+	}
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	if err := v.ReadConfig(strings.NewReader(sampleConfig)); err != nil {
+		t.Fatalf("sample config is not valid YAML: %v", err)
+	}
+
+	for key := range v.AllSettings() {
+		if !known[key] {
+			t.Errorf("sample config key %q has no matching config.Config mapstructure tag", key)
+		}
 	}
 }
 

--- a/cmd/plundrio/main.go
+++ b/cmd/plundrio/main.go
@@ -388,18 +388,21 @@ var runCmd = &cobra.Command{
 	},
 }
 
-var generateConfigCmd = &cobra.Command{
-	Use:   "generate-config",
-	Short: "Generate sample configuration file",
-	Run: func(cmd *cobra.Command, args []string) {
-		cfg := `# Plundrio configuration
+// sampleConfig is the YAML emitted by `generate-config`. Kept as a package
+// const (not inline) so a test can parse it and assert every key still maps to
+// a config.Config field — the same drift the flagViperBindings comment warns
+// about, but for the documented sample. Keep keys in sync with config.Config's
+// mapstructure tags.
+const sampleConfig = `# Plundrio configuration
 # Save as ~/.plundrio.yaml or specify with --config
 
-target: /path/to/downloads	# Target directory for downloads
-folder: "plundrio"					# Folder name on Put.io
-token: "" 									# Get a token with get-token
-listen: ":9091"							# Transmission RPC server address
-workers: 4									# Number of download workers
+target: /path/to/downloads   # Target directory for downloads
+folder: "plundrio"           # Folder name on Put.io
+token: ""                    # Get a token with get-token
+listen: ":9091"              # Transmission RPC server address
+workers: 4                   # Number of download workers
+transfer_check_interval: 0s  # How often to poll put.io for transfer state.
+                             # 0 = default (30s); values below 5s are rejected.
 post_complete_retention: 24h # Grace before DeleteTransfer on put.io after local
                              # download completes (window for *arr's torrent-remove);
                              # 0 disables — rely on the client to remove.
@@ -408,19 +411,28 @@ stall_timeout: 1h            # No-progress window before a put.io transfer is
 stall_max_retries: 1         # Stall retries before deleting (0 = delete on first stall).
 min_free_space: ""           # Opt-in floor on put.io free space (e.g. "20GB",
                              # "10GiB"); reject torrent-add below it. Empty disables.
+dashboard: false             # Enable the read-only web dashboard (default off).
+dashboard_addr: ":9092"      # Address the dashboard binds when enabled.
 download_start_window:       # Optional local download start window
   enabled: false
   start: "23:00"
   end: "05:00"
-log_level: "info"					  # Log level (debug,info,warn,error,fatal,none)
+log_level: "info"            # Log level (debug,info,warn,error,fatal,none)
 
 # Environment variables:
 # PLDR_TARGET, PLDR_FOLDER, PLDR_TOKEN, PLDR_LISTEN, PLDR_WORKERS,
-# PLDR_POST_COMPLETE_RETENTION, PLDR_STALL_TIMEOUT, PLDR_STALL_MAX_RETRIES,
-# PLDR_MIN_FREE_SPACE,
+# PLDR_TRANSFER_CHECK_INTERVAL, PLDR_POST_COMPLETE_RETENTION,
+# PLDR_STALL_TIMEOUT, PLDR_STALL_MAX_RETRIES, PLDR_MIN_FREE_SPACE,
+# PLDR_DASHBOARD, PLDR_DASHBOARD_ADDR,
 # PLDR_DOWNLOAD_START_WINDOW_ENABLED, PLDR_DOWNLOAD_START_WINDOW_START,
 # PLDR_DOWNLOAD_START_WINDOW_END, PLDR_LOG_LEVEL
 `
+
+var generateConfigCmd = &cobra.Command{
+	Use:   "generate-config",
+	Short: "Generate sample configuration file",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := sampleConfig
 
 		outputPath := "plundrio-config.yaml"
 		if len(args) > 0 {

--- a/cmd/plundrio/main.go
+++ b/cmd/plundrio/main.go
@@ -496,7 +496,12 @@ var getTokenCmd = &cobra.Command{
 			case <-ticker.C:
 				tokenResp, err := http.Get("https://api.put.io/v2/oauth2/oob/code/" + codeResponse.Code)
 				if err != nil {
-					log.Fatal("auth").Err(err).Msg("Failed to check authorization status")
+					// A transient network blip during the (up to 5-minute) poll
+					// must not abort the whole flow — the user may still be
+					// entering the code. Log and retry on the next tick; the
+					// ctx.Done() case enforces the overall timeout.
+					log.Warn("auth").Err(err).Msg("Failed to check authorization status, retrying")
+					continue
 				}
 
 				var tokenResult struct {

--- a/cmd/plundrio/overrides_path_test.go
+++ b/cmd/plundrio/overrides_path_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveOverridesPath covers the precedence the dashboard and main.go rely
+// on to find the runtime-overrides file: --overrides-file flag, then
+// PLDR_OVERRIDES_FILE, then <target>/.plundrio-overrides.json, then "" when no
+// target is known. A wrong result here would read/write overrides from the
+// wrong place.
+func TestResolveOverridesPath(t *testing.T) {
+	t.Run("flag wins over env and target", func(t *testing.T) {
+		t.Setenv("PLDR_OVERRIDES_FILE", "/from/env.json")
+		cmd := newTestRunCmd()
+		if err := cmd.ParseFlags([]string{"--overrides-file", "/from/flag.json"}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if got := resolveOverridesPath(cmd, "/some/target"); got != "/from/flag.json" {
+			t.Errorf("got %q, want /from/flag.json", got)
+		}
+	})
+
+	t.Run("env wins over target when no flag", func(t *testing.T) {
+		t.Setenv("PLDR_OVERRIDES_FILE", "/from/env.json")
+		cmd := newTestRunCmd()
+		if err := cmd.ParseFlags(nil); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if got := resolveOverridesPath(cmd, "/some/target"); got != "/from/env.json" {
+			t.Errorf("got %q, want /from/env.json", got)
+		}
+	})
+
+	t.Run("falls back to target dir", func(t *testing.T) {
+		t.Setenv("PLDR_OVERRIDES_FILE", "") // treated as unset
+		cmd := newTestRunCmd()
+		if err := cmd.ParseFlags(nil); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		want := filepath.Join("/some/target", ".plundrio-overrides.json")
+		if got := resolveOverridesPath(cmd, "/some/target"); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty when no flag, env, or target", func(t *testing.T) {
+		t.Setenv("PLDR_OVERRIDES_FILE", "")
+		cmd := newTestRunCmd()
+		if err := cmd.ParseFlags(nil); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if got := resolveOverridesPath(cmd, ""); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -9,6 +9,33 @@ import (
 	"testing"
 )
 
+// TestAuthenticateRejectsEmptyUsername: a 200 response whose account has no
+// username is treated as an auth failure (a malformed/invalid-token response),
+// while a populated username authenticates.
+func TestAuthenticateRejectsEmptyUsername(t *testing.T) {
+	t.Run("empty username fails", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"info":{"username":""}}`))
+		}))
+		defer srv.Close()
+		c := newTestClient(t, srv.URL)
+		if err := c.Authenticate(context.Background()); err == nil {
+			t.Error("expected error for empty username, got nil")
+		}
+	})
+
+	t.Run("populated username succeeds", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"info":{"username":"alice"}}`))
+		}))
+		defer srv.Close()
+		c := newTestClient(t, srv.URL)
+		if err := c.Authenticate(context.Background()); err != nil {
+			t.Errorf("Authenticate: %v", err)
+		}
+	})
+}
+
 // newTestClient builds an api.Client whose underlying go-putio client is pointed
 // at baseURL (an httptest server) instead of the real put.io. It reaches into
 // the unexported client field — legal within the package — because there is no

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+)
+
+// newTestClient builds an api.Client whose underlying go-putio client is pointed
+// at baseURL (an httptest server) instead of the real put.io. It reaches into
+// the unexported client field — legal within the package — because there is no
+// public BaseURL setter on api.Client.
+func newTestClient(t *testing.T, baseURL string) *Client {
+	t.Helper()
+	c := NewClient("test-token")
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse base url: %v", err)
+	}
+	c.client.BaseURL = u
+	return c
+}
+
+// fileJSON renders one put.io file/folder object. Folders are identified by the
+// x-directory content type, which is what File.IsDir keys on.
+func fileJSON(id int64, name string, size int64, dir bool) string {
+	ct := "video/x-matroska"
+	if dir {
+		ct = "application/x-directory"
+	}
+	i := strconv.FormatInt
+	return `{"id":` + i(id, 10) + `,"name":"` + name + `","size":` + i(size, 10) + `,"content_type":"` + ct + `"}`
+}
+
+// TestGetAllTransferFilesWalksTree verifies the recursive walk flattens a nested
+// put.io folder into leaf files with forward-slash relative paths rooted at the
+// transfer (the path-collision fix's contract).
+func TestGetAllTransferFilesWalksTree(t *testing.T) {
+	// Tree:
+	//   root(10, dir)
+	//   ├── movie.mkv(11)
+	//   └── Subs(12, dir)
+	//       └── english.srt(13)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/files/10", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"file":` + fileJSON(10, "Movie", 0, true) + `}`))
+	})
+	mux.HandleFunc("/v2/files/list", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("parent_id") {
+		case "10":
+			_, _ = w.Write([]byte(`{"files":[` + fileJSON(11, "movie.mkv", 100, false) + `,` + fileJSON(12, "Subs", 0, true) + `],"cursor":""}`))
+		case "12":
+			_, _ = w.Write([]byte(`{"files":[` + fileJSON(13, "english.srt", 50, false) + `],"cursor":""}`))
+		default:
+			http.Error(w, "unexpected parent_id", http.StatusBadRequest)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	files, err := c.GetAllTransferFiles(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetAllTransferFiles: %v", err)
+	}
+
+	got := map[string]int64{} // relPath -> size
+	for _, f := range files {
+		got[f.RelPath] = f.File.Size
+	}
+	want := map[string]int64{
+		"movie.mkv":        100,
+		"Subs/english.srt": 50,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d leaves %v, want %d %v", len(got), got, len(want), want)
+	}
+	for rel, size := range want {
+		if got[rel] != size {
+			t.Errorf("leaf %q size = %d, want %d", rel, got[rel], size)
+		}
+	}
+}
+
+// TestGetAllTransferFilesSingleFile covers the non-directory root: a transfer
+// whose file_id points straight at a leaf returns that one file, RelPath == name.
+func TestGetAllTransferFilesSingleFile(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/files/20", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"file":` + fileJSON(20, "single.mkv", 4096, false) + `}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	files, err := c.GetAllTransferFiles(context.Background(), 20)
+	if err != nil {
+		t.Fatalf("GetAllTransferFiles: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("got %d files, want 1", len(files))
+	}
+	if files[0].RelPath != "single.mkv" || files[0].File.Size != 4096 {
+		t.Errorf("got {RelPath:%q size:%d}, want {single.mkv 4096}", files[0].RelPath, files[0].File.Size)
+	}
+}
+
+// TestGetAllTransferFilesPropagatesError ensures an API failure on the root Get
+// surfaces as an error rather than an empty list.
+func TestGetAllTransferFilesPropagatesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error_type":"NotFound"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	if _, err := c.GetAllTransferFiles(context.Background(), 99); err == nil {
+		t.Fatal("expected error for 404 root file, got nil")
+	}
+}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -108,6 +108,95 @@ func TestGetAllTransferFilesSingleFile(t *testing.T) {
 	}
 }
 
+// TestEnsureFolderReturnsExisting: when a folder with the name already exists at
+// the put.io root, EnsureFolder returns its ID without creating a new one.
+func TestEnsureFolderReturnsExisting(t *testing.T) {
+	var createCalled bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/files/list", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"files":[` + fileJSON(555, "plundrio", 0, true) + `],"cursor":""}`))
+	})
+	mux.HandleFunc("/v2/files/create-folder", func(w http.ResponseWriter, r *http.Request) {
+		createCalled = true
+		http.Error(w, "should not create", http.StatusBadRequest)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	id, err := c.EnsureFolder(context.Background(), "plundrio")
+	if err != nil {
+		t.Fatalf("EnsureFolder: %v", err)
+	}
+	if id != 555 {
+		t.Errorf("folder id = %d, want 555 (existing)", id)
+	}
+	if createCalled {
+		t.Error("create-folder called for an already-existing folder")
+	}
+}
+
+// TestEnsureFolderCreatesWhenMissing: with no matching folder at the root,
+// EnsureFolder creates one and returns the new ID.
+func TestEnsureFolderCreatesWhenMissing(t *testing.T) {
+	var createCalled bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/files/list", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"files":[` + fileJSON(1, "other", 0, true) + `],"cursor":""}`))
+	})
+	mux.HandleFunc("/v2/files/create-folder", func(w http.ResponseWriter, r *http.Request) {
+		createCalled = true
+		_, _ = w.Write([]byte(`{"file":` + fileJSON(777, "plundrio", 0, true) + `}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	id, err := c.EnsureFolder(context.Background(), "plundrio")
+	if err != nil {
+		t.Fatalf("EnsureFolder: %v", err)
+	}
+	if id != 777 {
+		t.Errorf("folder id = %d, want 777 (created)", id)
+	}
+	if !createCalled {
+		t.Error("create-folder not called for a missing folder")
+	}
+}
+
+// TestAddTransferRejectsErrorStatus: a transfer that put.io immediately marks
+// ERROR (e.g. a bad magnet) must surface as an error from AddTransfer, not a
+// silent empty hash.
+func TestAddTransferRejectsErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"transfer":{"id":1,"status":"ERROR","error_message":"bad magnet"}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, err := c.AddTransfer(context.Background(), "magnet:?xt=bad", 42)
+	if err == nil {
+		t.Fatal("expected error for ERROR-status transfer, got nil")
+	}
+}
+
+// TestAddTransferReturnsHash: a healthy add returns the transfer hash.
+func TestAddTransferReturnsHash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"transfer":{"id":1,"status":"IN_QUEUE","hash":"deadbeef"}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	hash, err := c.AddTransfer(context.Background(), "magnet:?xt=ok", 42)
+	if err != nil {
+		t.Fatalf("AddTransfer: %v", err)
+	}
+	if hash != "deadbeef" {
+		t.Errorf("hash = %q, want deadbeef", hash)
+	}
+}
+
 // TestGetAllTransferFilesPropagatesError ensures an API failure on the root Get
 // surfaces as an error rather than an empty list.
 func TestGetAllTransferFilesPropagatesError(t *testing.T) {

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,47 @@
+// Package atomicfile provides crash-safe file replacement: write to a uniquely
+// named temp file in the same directory, then rename over the target. The rename
+// is atomic on POSIX, so a crash or full disk mid-write leaves either the old
+// complete file or the new one — never a truncated file.
+//
+// It is the single implementation behind the daemon's small JSON state files
+// (the category map and the runtime-overrides file), which previously each
+// carried their own copy of the temp+rename dance.
+package atomicfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteFile atomically writes data to path with the given permission bits.
+//
+// A uniquely named temp file (os.CreateTemp, not a fixed path+".tmp") lets two
+// concurrent writers each rename their own temp over the target without
+// clobbering a half-written shared temp — last writer wins, no corruption.
+// os.CreateTemp creates the temp 0600, so perm is applied via Chmod before the
+// rename. On any failure before the rename the temp file is removed; after a
+// successful rename that cleanup is a harmless no-op.
+func WriteFile(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp file into place: %w", err)
+	}
+	return nil
+}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,97 @@
+package atomicfile
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func TestWriteFileWritesContentWithPerm(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	if err := WriteFile(path, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(got, []byte("hello")) {
+		t.Errorf("content = %q, want hello", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Errorf("perm = %o, want 644", info.Mode().Perm())
+	}
+}
+
+func TestWriteFileReplacesAtomicallyLeavingNoTemp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	if err := WriteFile(path, []byte("first"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := WriteFile(path, []byte("second"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, _ := os.ReadFile(path)
+	if !bytes.Equal(got, []byte("second")) {
+		t.Errorf("content = %q, want second", got)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "state.json" {
+			t.Errorf("leftover temp file: %q", e.Name())
+		}
+	}
+}
+
+func TestWriteFileConcurrentWritersDoNotCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Each writer writes a complete, valid payload; with unique temp
+			// names + atomic rename the final file must be exactly one of them,
+			// never a mix.
+			_ = WriteFile(path, []byte("payload-"+strconv.Itoa(i)), 0o644)
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.HasPrefix(got, []byte("payload-")) {
+		t.Errorf("final file is not a complete payload: %q", got)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Errorf("expected only the target file, got %d entries", len(entries))
+	}
+}
+
+func TestWriteFileErrorsOnUnwritableDir(t *testing.T) {
+	// A non-existent parent directory makes os.CreateTemp fail, surfaced as an
+	// error rather than a panic.
+	if err := WriteFile(filepath.Join(t.TempDir(), "nope", "state.json"), []byte("x"), 0o644); err == nil {
+		t.Error("expected error writing into a missing directory, got nil")
+	}
+}

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
 
+	"github.com/doodla/plundrio/internal/atomicfile"
 	"github.com/spf13/viper"
 )
 
@@ -180,31 +180,12 @@ func WriteOverride(path string, updates map[string]any) error {
 		return fmt.Errorf("marshal overrides: %w", err)
 	}
 
-	// Unique temp name (not a fixed path+".tmp") so two concurrent writers —
-	// e.g. two dashboard tabs PUTting settings at once — can't clobber each
-	// other's half-written temp file before the rename. Each rename atomically
-	// replaces the target; last writer wins, no corruption.
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return fmt.Errorf("create overrides temp file: %w", err)
-	}
-	tmpName := tmp.Name()
-	defer func() { _ = os.Remove(tmpName) }() // no-op after a successful rename
-
-	if _, err := tmp.Write(append(data, '\n')); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("write overrides temp file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close overrides temp file: %w", err)
-	}
-	// CreateTemp makes 0600; match the prior 0644 so the file stays readable.
-	if err := os.Chmod(tmpName, 0644); err != nil {
-		return fmt.Errorf("chmod overrides temp file: %w", err)
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		return fmt.Errorf("rename overrides temp file into place: %w", err)
+	// Atomic temp+rename (see atomicfile.WriteFile): a crash mid-write can't
+	// corrupt the file, and concurrent writers (e.g. two dashboard tabs) don't
+	// clobber each other's temp. writeMu above additionally serializes the
+	// load-merge-write so neither loses the other's keys.
+	if err := atomicfile.WriteFile(path, append(data, '\n'), 0644); err != nil {
+		return fmt.Errorf("write overrides: %w", err)
 	}
 	return nil
 }

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -167,12 +168,30 @@ func WriteOverride(path string, updates map[string]any) error {
 		return fmt.Errorf("marshal overrides: %w", err)
 	}
 
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, append(data, '\n'), 0644); err != nil {
+	// Unique temp name (not a fixed path+".tmp") so two concurrent writers —
+	// e.g. two dashboard tabs PUTting settings at once — can't clobber each
+	// other's half-written temp file before the rename. Each rename atomically
+	// replaces the target; last writer wins, no corruption.
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create overrides temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op after a successful rename
+
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		_ = tmp.Close()
 		return fmt.Errorf("write overrides temp file: %w", err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close overrides temp file: %w", err)
+	}
+	// CreateTemp makes 0600; match the prior 0644 so the file stays readable.
+	if err := os.Chmod(tmpName, 0644); err != nil {
+		return fmt.Errorf("chmod overrides temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
 		return fmt.Errorf("rename overrides temp file into place: %w", err)
 	}
 	return nil

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/spf13/viper"
 )
@@ -134,11 +135,19 @@ func ApplyOverrides(v *viper.Viper, ov Overrides) []string {
 	return applied
 }
 
+// writeMu serializes the load-merge-write in WriteOverride. The atomic rename
+// prevents a torn file, but without this lock two concurrent writers (e.g. two
+// dashboard tabs PUTting at once) would each read the same base, merge their own
+// key, and one rename would clobber the other's update (lost update). Process-
+// global because override writes are rare and always target the one file.
+var writeMu sync.Mutex
+
 // WriteOverride merges the given key/value pairs into the overrides file at
 // path, preserving keys already present and not in updates. Only canonical
 // OverrideKeys are written; unknown keys are rejected so a typo can't silently
 // persist a dead key. Writes atomically (temp file + rename) with 0644, matching
-// the CategoryStore persistence precedent's permissions.
+// the CategoryStore persistence precedent's permissions. The load-merge-write is
+// serialized (writeMu) so concurrent writers can't lose each other's updates.
 //
 // A nil/empty value for a key is rejected by callers (validation lives in the
 // settings PUT handler); WriteOverride itself just persists what it's given.
@@ -151,6 +160,9 @@ func WriteOverride(path string, updates map[string]any) error {
 			return fmt.Errorf("refusing to persist unknown override key %q", k)
 		}
 	}
+
+	writeMu.Lock()
+	defer writeMu.Unlock()
 
 	existing, err := LoadOverrides(path)
 	if err != nil {

--- a/internal/config/overrides_test.go
+++ b/internal/config/overrides_test.go
@@ -228,6 +228,31 @@ func TestWriteOverrideRoundTrips(t *testing.T) {
 	}
 }
 
+// TestWriteOverrideLeavesNoTempFiles asserts the atomic write cleans up its
+// unique temp file, leaving only the overrides file in the directory.
+func TestWriteOverrideLeavesNoTempFiles(t *testing.T) {
+	clearPLDREnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "overrides.json")
+
+	if err := WriteOverride(path, map[string]any{"workers": 8}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := WriteOverride(path, map[string]any{"log_level": "debug"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "overrides.json" {
+			t.Errorf("unexpected leftover file: %q", e.Name())
+		}
+	}
+}
+
 // TestWriteOverrideRejectsUnknownKey guards against a typo silently persisting a
 // dead key.
 func TestWriteOverrideRejectsUnknownKey(t *testing.T) {

--- a/internal/config/overrides_test.go
+++ b/internal/config/overrides_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -249,6 +250,52 @@ func TestWriteOverrideLeavesNoTempFiles(t *testing.T) {
 	for _, e := range entries {
 		if e.Name() != "overrides.json" {
 			t.Errorf("unexpected leftover file: %q", e.Name())
+		}
+	}
+}
+
+// TestWriteOverrideConcurrentNoLostUpdates hammers WriteOverride from many
+// goroutines, each persisting a distinct key. Serialized load-merge-write means
+// every key must survive — without the lock, concurrent writers would read the
+// same base and clobber each other (lost update), leaving only one key.
+func TestWriteOverrideConcurrentNoLostUpdates(t *testing.T) {
+	clearPLDREnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "overrides.json")
+
+	// Distinct persistable keys with distinct values.
+	type kv struct {
+		key string
+		val any
+	}
+	writes := []kv{
+		{"workers", 7},
+		{"log_level", "debug"},
+		{"token", "secret"},
+		{"listen", ":9091"},
+		{"dashboard_addr", ":9092"},
+		{"folder", "media"},
+	}
+
+	var wg sync.WaitGroup
+	for _, w := range writes {
+		wg.Add(1)
+		go func(w kv) {
+			defer wg.Done()
+			if err := WriteOverride(path, map[string]any{w.key: w.val}); err != nil {
+				t.Errorf("WriteOverride(%s): %v", w.key, err)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	ov, err := LoadOverrides(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	for _, w := range writes {
+		if _, ok := ov[w.key]; !ok {
+			t.Errorf("key %q missing after concurrent writes (lost update)", w.key)
 		}
 	}
 }

--- a/internal/download/category.go
+++ b/internal/download/category.go
@@ -17,6 +17,11 @@ type CategoryStore struct {
 	mu        sync.RWMutex
 	mapping   map[string]string
 	stateFile string
+
+	// saveMu serializes save() so two concurrent Set/Remove calls can't
+	// interleave their temp-file writes or rename a stale snapshot over a fresh
+	// one. Separate from mu so a save never blocks a Get.
+	saveMu sync.Mutex
 }
 
 func newCategoryStore(targetDir string) *CategoryStore {
@@ -73,7 +78,16 @@ func (cs *CategoryStore) Remove(hash string) {
 	cs.save()
 }
 
+// save persists the mapping atomically: marshal a consistent snapshot, write it
+// to a temp file in the same directory, then rename over the state file. The
+// rename is atomic on POSIX, so a crash or full disk mid-write leaves either the
+// old complete file or the new one — never a truncated file that would lose
+// every category mapping on the next Load (sending all downloads to the flat
+// target dir). saveMu serializes concurrent saves so the last writer wins.
 func (cs *CategoryStore) save() {
+	cs.saveMu.Lock()
+	defer cs.saveMu.Unlock()
+
 	cs.mu.RLock()
 	data, err := json.Marshal(cs.mapping)
 	cs.mu.RUnlock()
@@ -83,7 +97,33 @@ func (cs *CategoryStore) save() {
 		return
 	}
 
-	if err := os.WriteFile(cs.stateFile, data, 0644); err != nil {
+	dir := filepath.Dir(cs.stateFile)
+	tmp, err := os.CreateTemp(dir, stateFileName+".tmp-*")
+	if err != nil {
+		log.Error("categories").Err(err).Msg("Failed to create temp category state file")
+		return
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail before the rename; after a successful
+	// rename the temp path no longer exists and Remove is a harmless no-op.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		log.Error("categories").Err(err).Msg("Failed to write temp category state")
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		log.Error("categories").Err(err).Msg("Failed to close temp category state")
+		return
+	}
+	// CreateTemp makes the file 0600; match the previous 0644 so the state stays
+	// world-readable as before.
+	if err := os.Chmod(tmpName, 0644); err != nil {
+		log.Error("categories").Err(err).Msg("Failed to chmod temp category state")
+		return
+	}
+	if err := os.Rename(tmpName, cs.stateFile); err != nil {
 		log.Error("categories").Err(err).Msg("Failed to save category state")
 	}
 }

--- a/internal/download/category.go
+++ b/internal/download/category.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/doodla/plundrio/internal/atomicfile"
 	"github.com/doodla/plundrio/internal/log"
 )
 
@@ -78,12 +79,11 @@ func (cs *CategoryStore) Remove(hash string) {
 	cs.save()
 }
 
-// save persists the mapping atomically: marshal a consistent snapshot, write it
-// to a temp file in the same directory, then rename over the state file. The
-// rename is atomic on POSIX, so a crash or full disk mid-write leaves either the
-// old complete file or the new one — never a truncated file that would lose
-// every category mapping on the next Load (sending all downloads to the flat
-// target dir). saveMu serializes concurrent saves so the last writer wins.
+// save persists the mapping atomically (see atomicfile.WriteFile): a crash or
+// full disk mid-write leaves either the old complete file or the new one, never
+// a truncated file that would lose every category mapping on the next Load
+// (sending all downloads to the flat target dir). saveMu serializes concurrent
+// saves so the last writer wins.
 func (cs *CategoryStore) save() {
 	cs.saveMu.Lock()
 	defer cs.saveMu.Unlock()
@@ -97,33 +97,7 @@ func (cs *CategoryStore) save() {
 		return
 	}
 
-	dir := filepath.Dir(cs.stateFile)
-	tmp, err := os.CreateTemp(dir, stateFileName+".tmp-*")
-	if err != nil {
-		log.Error("categories").Err(err).Msg("Failed to create temp category state file")
-		return
-	}
-	tmpName := tmp.Name()
-	// Best-effort cleanup if we bail before the rename; after a successful
-	// rename the temp path no longer exists and Remove is a harmless no-op.
-	defer func() { _ = os.Remove(tmpName) }()
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		log.Error("categories").Err(err).Msg("Failed to write temp category state")
-		return
-	}
-	if err := tmp.Close(); err != nil {
-		log.Error("categories").Err(err).Msg("Failed to close temp category state")
-		return
-	}
-	// CreateTemp makes the file 0600; match the previous 0644 so the state stays
-	// world-readable as before.
-	if err := os.Chmod(tmpName, 0644); err != nil {
-		log.Error("categories").Err(err).Msg("Failed to chmod temp category state")
-		return
-	}
-	if err := os.Rename(tmpName, cs.stateFile); err != nil {
+	if err := atomicfile.WriteFile(cs.stateFile, data, 0644); err != nil {
 		log.Error("categories").Err(err).Msg("Failed to save category state")
 	}
 }

--- a/internal/download/category_test.go
+++ b/internal/download/category_test.go
@@ -3,6 +3,8 @@ package download
 import (
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"testing"
 )
 
@@ -76,6 +78,54 @@ func TestCategoryStore_LoadMissingFile(t *testing.T) {
 
 	if got := cs.Get("anything"); got != "" {
 		t.Errorf("Get after Load of missing file = %q, want %q", got, "")
+	}
+}
+
+func TestCategoryStore_SaveLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	cs := newCategoryStore(dir)
+
+	cs.Set("hash1", "tv")
+	cs.Set("hash2", "movies")
+	cs.Remove("hash1")
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	// Only the state file should remain — the atomic temp file is renamed away.
+	for _, e := range entries {
+		if e.Name() != stateFileName {
+			t.Errorf("unexpected leftover file in state dir: %q", e.Name())
+		}
+	}
+}
+
+func TestCategoryStore_ConcurrentSavesPersistConsistently(t *testing.T) {
+	dir := t.TempDir()
+	cs := newCategoryStore(dir)
+
+	// Hammer Set from many goroutines. With atomic temp+rename and saveMu, the
+	// on-disk file must always be complete, parseable JSON — never a truncated
+	// half-write. The final reload must see every key.
+	const n = 50
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cs.Set("hash"+strconv.Itoa(i), "cat"+strconv.Itoa(i))
+		}(i)
+	}
+	wg.Wait()
+
+	cs2 := newCategoryStore(dir)
+	cs2.Load()
+	for i := 0; i < n; i++ {
+		want := "cat" + strconv.Itoa(i)
+		if got := cs2.Get("hash" + strconv.Itoa(i)); got != want {
+			t.Errorf("after concurrent saves Get(hash%d) = %q, want %q", i, got, want)
+		}
 	}
 }
 

--- a/internal/download/cleanup_test.go
+++ b/internal/download/cleanup_test.go
@@ -27,6 +27,10 @@ type fakePutioClient struct {
 	deleteFileErr     error
 	deleteTransferErr error
 
+	// downloadURL, when set, is returned by GetDownloadURL so the real grab
+	// download path can be exercised against a local httptest server.
+	downloadURL string
+
 	// Optional programmable hooks for tests that need richer behavior
 	// (transfers_test.go uses these to drive the failed-retry cascade).
 	getAllTransferFilesFn func(fileID int64) ([]api.TransferFile, error)
@@ -60,7 +64,9 @@ func (f *fakePutioClient) RetryTransfer(ctx context.Context, transferID int64) (
 	return nil, nil
 }
 func (f *fakePutioClient) GetDownloadURL(ctx context.Context, fileID int64) (string, error) {
-	return "", nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.downloadURL, nil
 }
 func (f *fakePutioClient) DeleteFile(ctx context.Context, fileID int64) error {
 	f.mu.Lock()

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -81,7 +81,7 @@ func (m *Manager) downloadWithRetry(state *DownloadState) error {
 	var lastErr error
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		if err := m.downloadFile(state); err != nil {
+		if err := m.downloadFileFn(state); err != nil {
 			// Check for cancellation first - pass it through without wrapping
 			if downloadErr, ok := err.(*DownloadError); ok && downloadErr.Type == "DownloadCancelled" {
 				return err
@@ -91,13 +91,25 @@ func (m *Manager) downloadWithRetry(state *DownloadState) error {
 			if !isTransientError(err) {
 				return fmt.Errorf("permanent error on attempt %d: %w", attempt, err)
 			}
+			// No point backing off after the final attempt — we're about to
+			// give up. Avoids a wasted multi-second sleep per file that's going
+			// to fail anyway (and that the failed-transfer cascade will retry).
+			if attempt == maxRetries {
+				break
+			}
 			log.Warn("download").
 				Str("file_name", state.Name).
 				Int64("file_id", state.FileID).
 				Int("attempt", attempt).
 				Err(err).
 				Msg("Retrying download after error")
-			time.Sleep(time.Second * time.Duration(attempt))
+			// Cancellable backoff: a shutdown must retire the worker promptly
+			// rather than blocking Stop()'s workerWg.Wait() on a full sleep.
+			select {
+			case <-time.After(m.retryBackoffBase * time.Duration(attempt)):
+			case <-m.stopChan:
+				return NewDownloadCancelledError(state.Name, "shutdown during retry backoff")
+			}
 			continue
 		}
 		return nil

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 
 	grab "github.com/cavaliergopher/grab/v3"
 )
@@ -102,5 +103,70 @@ func TestIsTransientError(t *testing.T) {
 				t.Errorf("isTransientError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDownloadWithRetryStopsAtMaxAttempts(t *testing.T) {
+	m := newTestManagerWithClient(&fakePutioClient{})
+	m.retryBackoffBase = time.Microsecond // keep the backoff negligible
+
+	// A persistently transient error must be retried exactly maxRetries (3)
+	// times, then give up. The backoff after the final attempt is skipped.
+	attempts := 0
+	transient := fmt.Errorf(`Get "https://cdn/x": read tcp 1.2.3.4:443: read: %w`, syscall.ECONNRESET)
+	m.downloadFileFn = func(*DownloadState) error {
+		attempts++
+		return transient
+	}
+
+	err := m.downloadWithRetry(&DownloadState{Name: "x", FileID: 1, TransferID: 1})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestDownloadWithRetryDoesNotRetryPermanentError(t *testing.T) {
+	m := newTestManagerWithClient(&fakePutioClient{})
+
+	attempts := 0
+	m.downloadFileFn = func(*DownloadState) error {
+		attempts++
+		return errors.New("404 not found") // not classified transient
+	}
+
+	if err := m.downloadWithRetry(&DownloadState{Name: "x"}); err == nil {
+		t.Fatal("expected permanent error, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry on permanent error)", attempts)
+	}
+}
+
+func TestDownloadWithRetryBackoffCancelledByShutdown(t *testing.T) {
+	m := newTestManagerWithClient(&fakePutioClient{})
+	// Large backoff so the test would hang for seconds if the select didn't
+	// honor stopChan — proving the cancellable-backoff path.
+	m.retryBackoffBase = time.Hour
+
+	transient := fmt.Errorf(`Get "https://cdn/x": read tcp: read: %w`, syscall.ECONNRESET)
+	m.downloadFileFn = func(*DownloadState) error { return transient }
+
+	// Close stopChan so the first backoff select returns immediately.
+	close(m.stopChan)
+
+	done := make(chan error, 1)
+	go func() { done <- m.downloadWithRetry(&DownloadState{Name: "x"}) }()
+
+	select {
+	case err := <-done:
+		var de *DownloadError
+		if !errors.As(err, &de) || de.Type != "DownloadCancelled" {
+			t.Errorf("err = %v, want DownloadCancelled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("downloadWithRetry did not return promptly on shutdown during backoff")
 	}
 }

--- a/internal/download/e2e_test.go
+++ b/internal/download/e2e_test.go
@@ -1,0 +1,129 @@
+package download
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestDownloadFileE2ESucceeds drives the real grab download path end-to-end:
+// downloadWithRetry → downloadFile → grab fetches bytes from a local httptest
+// "CDN" and lands them at <target>/<name>, and the transfer context's
+// downloaded-byte accounting reflects the full file.
+func TestDownloadFileE2ESucceeds(t *testing.T) {
+	content := bytes.Repeat([]byte("plundrio-e2e-"), 1024) // ~13KB
+
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		_, _ = w.Write(content)
+	}))
+	defer cdn.Close()
+
+	dir := t.TempDir()
+	fake := &fakePutioClient{downloadURL: cdn.URL + "/movie.mkv"}
+	m := newTestManagerWithClientAndTargetDir(fake, dir)
+
+	m.coordinator.InitiateTransfer(1, "Movie", 10, 1)
+	if err := m.coordinator.StartDownload(1); err != nil {
+		t.Fatalf("StartDownload: %v", err)
+	}
+
+	state := &DownloadState{
+		FileID:     100,
+		Name:       filepath.Join("Movie", "movie.mkv"),
+		TransferID: 1,
+		StartTime:  time.Now(),
+	}
+	if err := m.downloadWithRetry(state); err != nil {
+		t.Fatalf("downloadWithRetry: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "Movie", "movie.mkv"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("downloaded %d bytes, want %d (content mismatch)", len(got), len(content))
+	}
+
+	// The flush-on-complete path should have recorded the full size on the ctx.
+	ctx, _ := m.coordinator.GetTransferContext(1)
+	downloaded, _, _, _ := ctx.GetProgress()
+	if downloaded != int64(len(content)) {
+		t.Errorf("ctx downloaded = %d, want %d", downloaded, len(content))
+	}
+}
+
+// TestDownloadFileE2ERetriesTransientThenSucceeds proves downloadWithRetry
+// recovers from a transient HTTP 503 on the CDN: the first attempt fails with a
+// retryable status, the second succeeds, and the file lands intact.
+func TestDownloadFileE2ERetriesTransientThenSucceeds(t *testing.T) {
+	content := []byte("recovered after a 503\n")
+
+	var hits int32
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&hits, 1) == 1 {
+			http.Error(w, "busy", http.StatusServiceUnavailable) // transient
+			return
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		_, _ = w.Write(content)
+	}))
+	defer cdn.Close()
+
+	dir := t.TempDir()
+	fake := &fakePutioClient{downloadURL: cdn.URL + "/ep.mkv"}
+	m := newTestManagerWithClientAndTargetDir(fake, dir)
+	m.retryBackoffBase = time.Millisecond // keep the retry near-instant
+
+	state := &DownloadState{
+		FileID:     100,
+		Name:       filepath.Join("Show", "ep.mkv"),
+		TransferID: 1,
+		StartTime:  time.Now(),
+	}
+	if err := m.downloadWithRetry(state); err != nil {
+		t.Fatalf("downloadWithRetry: %v", err)
+	}
+
+	if n := atomic.LoadInt32(&hits); n != 2 {
+		t.Errorf("CDN hits = %d, want 2 (one 503, one success)", n)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "Show", "ep.mkv"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("content mismatch after retry: got %q", got)
+	}
+}
+
+// TestDownloadFileE2EPermanentErrorDoesNotRetry confirms a non-retryable CDN
+// status (404) fails fast without burning the retry budget.
+func TestDownloadFileE2EPermanentErrorDoesNotRetry(t *testing.T) {
+	var hits int32
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		http.Error(w, "gone", http.StatusNotFound)
+	}))
+	defer cdn.Close()
+
+	dir := t.TempDir()
+	fake := &fakePutioClient{downloadURL: cdn.URL + "/missing.mkv"}
+	m := newTestManagerWithClientAndTargetDir(fake, dir)
+	m.retryBackoffBase = time.Millisecond
+
+	state := &DownloadState{FileID: 100, Name: filepath.Join("X", "missing.mkv"), TransferID: 1, StartTime: time.Now()}
+	if err := m.downloadWithRetry(state); err == nil {
+		t.Fatal("expected error for 404 download, got nil")
+	}
+	if n := atomic.LoadInt32(&hits); n != 1 {
+		t.Errorf("CDN hits = %d, want 1 (404 is not retried)", n)
+	}
+}

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -3,6 +3,7 @@ package download
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/doodla/go-putio"
 	"github.com/doodla/plundrio/internal/api"
@@ -60,6 +61,16 @@ type Manager struct {
 	workerCount int
 
 	processor *TransferProcessor // Handles transfer processing
+
+	// downloadFileFn performs a single download attempt; it is a seam (defaults
+	// to m.downloadFile in New) so downloadWithRetry's retry/backoff/cancellation
+	// logic is unit-testable without touching the network. Mirrors the
+	// clock/sleeper injection used in the api package and processFailedTransfersAt.
+	downloadFileFn func(*DownloadState) error
+	// retryBackoffBase is the base unit of the linear download backoff (attempt N
+	// waits N*base). Defaults to time.Second in New; tests set it low to keep the
+	// retry path fast.
+	retryBackoffBase time.Duration
 }
 
 // Context returns the manager's lifecycle context.
@@ -140,6 +151,10 @@ func New(cfg *config.Config, client PutioClient) *Manager {
 		workerQuit:  make(chan struct{}, 256),
 		activeFiles: sync.Map{},
 	}
+
+	// Default the download seams to production behavior; tests override them.
+	m.downloadFileFn = m.downloadFile
+	m.retryBackoffBase = time.Second
 
 	// Initialize coordinator and processor
 	m.processor = newTransferProcessor(m)

--- a/internal/download/progress.go
+++ b/internal/download/progress.go
@@ -39,13 +39,17 @@ func (m *Manager) monitorGrabDownloadProgress(ctx context.Context, state *Downlo
 					state.downloaded = bytesComplete
 					state.Progress = resp.Progress()
 
-					// Calculate ETA based on current download rate
+					// Average download rate since start. Guarded against a zero
+					// elapsed so speedBps never becomes +Inf/NaN — it feeds the ETA,
+					// the dashboard's rate_download, and the RPC rateDownload, none
+					// of which should ever see a bogus rate.
 					elapsed := time.Since(state.StartTime).Seconds()
+					var speedBps float64
 					if elapsed > 0 {
-						speed := float64(state.downloaded) / elapsed
-						remaining := float64(totalSize - state.downloaded)
-						if speed > 0 {
-							etaSeconds := remaining / speed
+						speedBps = float64(state.downloaded) / elapsed
+						if speedBps > 0 {
+							remaining := float64(totalSize - state.downloaded)
+							etaSeconds := remaining / speedBps
 							state.ETA = time.Now().Add(time.Duration(etaSeconds) * time.Second)
 						}
 					}
@@ -53,7 +57,7 @@ func (m *Manager) monitorGrabDownloadProgress(ctx context.Context, state *Downlo
 					downloadedMB := float64(state.downloaded) / 1024 / 1024
 					totalMB := float64(totalSize) / 1024 / 1024
 					progress := state.Progress * 100
-					speedMBps := downloadedMB / elapsed
+					speedMBps := speedBps / 1024 / 1024
 					eta := time.Until(state.ETA).Round(time.Second)
 					state.LastProgress = time.Now()
 					state.mu.Unlock()
@@ -61,7 +65,7 @@ func (m *Manager) monitorGrabDownloadProgress(ctx context.Context, state *Downlo
 					// Update transfer context with downloaded bytes if it exists
 					if exists && bytesDelta > 0 {
 						transferCtx.AddDownloadedBytes(bytesDelta)
-						transferCtx.SetLocalProgress(speedMBps*1024*1024, state.ETA)
+						transferCtx.SetLocalProgress(speedBps, state.ETA)
 
 						downloadedSize, transferTotal, _, _ := transferCtx.GetProgress()
 

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1,0 +1,271 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/doodla/go-putio"
+	"github.com/doodla/plundrio/internal/api"
+	"github.com/doodla/plundrio/internal/config"
+	"github.com/doodla/plundrio/internal/download"
+)
+
+// e2eClient is a put.io fake satisfying BOTH server.PutioClient and
+// download.PutioClient, so an end-to-end test can drive the real download.Manager
+// and the real RPC Server together with no network. GetDownloadURL points at a
+// local httptest "CDN" so grab performs a genuine HTTP download to disk.
+type e2eClient struct {
+	mu          sync.Mutex
+	transfers   map[int64]*putio.Transfer
+	files       map[int64][]api.TransferFile
+	downloadURL string
+	account     *putio.AccountInfo
+
+	deleteFileCalls     []int64
+	deleteTransferCalls []int64
+}
+
+func (c *e2eClient) GetAccountInfo(context.Context) (*putio.AccountInfo, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.account != nil {
+		return c.account, nil
+	}
+	return &putio.AccountInfo{Username: "e2e"}, nil
+}
+
+func (c *e2eClient) GetTransfers(context.Context) ([]*putio.Transfer, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]*putio.Transfer, 0, len(c.transfers))
+	for _, t := range c.transfers {
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+func (c *e2eClient) UploadFile(context.Context, []byte, string, int64) (string, error) {
+	return "uploaded", nil
+}
+
+func (c *e2eClient) AddTransfer(context.Context, string, int64) (string, error) {
+	return "magnet", nil
+}
+
+func (c *e2eClient) DeleteFile(_ context.Context, fileID int64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deleteFileCalls = append(c.deleteFileCalls, fileID)
+	return nil
+}
+
+func (c *e2eClient) DeleteTransfer(_ context.Context, transferID int64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deleteTransferCalls = append(c.deleteTransferCalls, transferID)
+	delete(c.transfers, transferID) // simulate put.io removing the transfer
+	return nil
+}
+
+func (c *e2eClient) GetAllTransferFiles(_ context.Context, fileID int64) ([]api.TransferFile, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.files[fileID], nil
+}
+
+func (c *e2eClient) RetryTransfer(context.Context, int64) (*putio.Transfer, error) {
+	return nil, nil
+}
+
+func (c *e2eClient) GetDownloadURL(context.Context, int64) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.downloadURL, nil
+}
+
+// waitFor polls cond until it returns true or the deadline elapses.
+func waitFor(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", d)
+}
+
+// TestE2ECompletedTransferDownloadsAndCleansUp exercises the full happy path
+// with the real Manager + Server wired together:
+//
+//	put.io reports a COMPLETED transfer → Manager downloads its file (real grab
+//	HTTP fetch) into the category/transfer subdir → torrent-get reports it done →
+//	torrent-remove purges the put.io side and clears the category mapping.
+func TestE2ECompletedTransferDownloadsAndCleansUp(t *testing.T) {
+	content := []byte("plundrio end-to-end payload: the quick brown fox jumps\n")
+
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(content)
+	}))
+	defer cdn.Close()
+
+	const folderID int64 = 42
+	fake := &e2eClient{
+		transfers: map[int64]*putio.Transfer{
+			1: {
+				ID: 1, Hash: "abc", Name: "Movie.2024", FileID: 10,
+				SaveParentID: folderID, Status: "COMPLETED", PercentDone: 100,
+				Size: len(content),
+			},
+		},
+		files: map[int64][]api.TransferFile{
+			10: {{
+				File:    &putio.File{ID: 100, Name: "movie.mkv", Size: int64(len(content))},
+				RelPath: "movie.mkv",
+			}},
+		},
+		downloadURL: cdn.URL + "/movie.mkv",
+	}
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		TargetDir:             dir,
+		FolderID:              folderID,
+		WorkerCount:           2,
+		TransferCheckInterval: 20 * time.Millisecond, // poll fast for a snappy test
+	}
+
+	mgr := download.New(cfg, fake)
+	mgr.Start()
+	defer mgr.Stop()
+
+	// The file must land on disk under <target>/<transfer name>/<relpath> with
+	// the exact bytes the CDN served.
+	target := filepath.Join(dir, "Movie.2024", "movie.mkv")
+	waitFor(t, 5*time.Second, func() bool {
+		got, err := os.ReadFile(target)
+		return err == nil && bytes.Equal(got, content)
+	})
+
+	srv := New(cfg, fake, mgr)
+
+	// torrent-get must report the transfer (the put.io snapshot drives it).
+	req := rpcRequest(t, "torrent-get", map[string]interface{}{"fields": []string{"id", "percentDone", "hashString"}})
+	w := httptest.NewRecorder()
+	srv.handleRPC(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("torrent-get status = %d", w.Code)
+	}
+	resp := decodeRPCResponse(t, w.Body.Bytes())
+	torrents, _ := resp.Arguments["torrents"].([]interface{})
+	if len(torrents) != 1 {
+		t.Fatalf("torrent-get returned %d torrents, want 1", len(torrents))
+	}
+	got := torrents[0].(map[string]interface{})
+	if got["hashString"] != "abc" {
+		t.Errorf("hashString = %v, want abc", got["hashString"])
+	}
+	// Local download finished, so combined progress is 100% (1.0).
+	if pd, _ := got["percentDone"].(float64); pd != 1.0 {
+		t.Errorf("percentDone = %v, want 1.0", pd)
+	}
+
+	// torrent-remove must purge the put.io side (DeleteFile + DeleteTransfer).
+	rmReq := rpcRequest(t, "torrent-remove", map[string]interface{}{
+		"ids":               []string{"abc"},
+		"delete-local-data": false,
+	})
+	rmW := httptest.NewRecorder()
+	srv.handleRPC(rmW, rmReq)
+	if rmW.Code != http.StatusOK {
+		t.Fatalf("torrent-remove status = %d", rmW.Code)
+	}
+
+	fake.mu.Lock()
+	delFiles := append([]int64(nil), fake.deleteFileCalls...)
+	delTransfers := append([]int64(nil), fake.deleteTransferCalls...)
+	fake.mu.Unlock()
+
+	if !contains(delFiles, 10) {
+		t.Errorf("DeleteFile calls = %v, want to include file 10", delFiles)
+	}
+	if !contains(delTransfers, 1) {
+		t.Errorf("DeleteTransfer calls = %v, want to include transfer 1", delTransfers)
+	}
+
+	// The downloaded data is left on disk (delete-local-data was false).
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("local file should remain after remove without delete-local-data: %v", err)
+	}
+}
+
+// TestE2EDeleteLocalDataRemovesDownloadedFile is the e2e variant where the
+// client asks to also delete local data: the downloaded tree must be gone.
+func TestE2EDeleteLocalDataRemovesDownloadedFile(t *testing.T) {
+	content := []byte("delete-me payload\n")
+
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		_, _ = w.Write(content)
+	}))
+	defer cdn.Close()
+
+	const folderID int64 = 7
+	fake := &e2eClient{
+		transfers: map[int64]*putio.Transfer{
+			1: {ID: 1, Hash: "h", Name: "Show.S01E01", FileID: 10, SaveParentID: folderID, Status: "SEEDING", PercentDone: 100, Size: len(content)},
+		},
+		files: map[int64][]api.TransferFile{
+			10: {{File: &putio.File{ID: 100, Name: "ep.mkv", Size: int64(len(content))}, RelPath: "ep.mkv"}},
+		},
+		downloadURL: cdn.URL + "/ep.mkv",
+	}
+
+	dir := t.TempDir()
+	cfg := &config.Config{TargetDir: dir, FolderID: folderID, WorkerCount: 1, TransferCheckInterval: 20 * time.Millisecond}
+	mgr := download.New(cfg, fake)
+	mgr.Start()
+	defer mgr.Stop()
+
+	transferDir := filepath.Join(dir, "Show.S01E01")
+	target := filepath.Join(transferDir, "ep.mkv")
+	waitFor(t, 5*time.Second, func() bool {
+		got, err := os.ReadFile(target)
+		return err == nil && bytes.Equal(got, content)
+	})
+
+	srv := New(cfg, fake, mgr)
+	rmReq := rpcRequest(t, "torrent-remove", map[string]interface{}{
+		"ids":               []string{"h"},
+		"delete-local-data": true,
+	})
+	rmW := httptest.NewRecorder()
+	srv.handleRPC(rmW, rmReq)
+	if rmW.Code != http.StatusOK {
+		t.Fatalf("torrent-remove status = %d", rmW.Code)
+	}
+
+	if _, err := os.Stat(transferDir); !os.IsNotExist(err) {
+		t.Errorf("transfer dir should be deleted with delete-local-data, stat err = %v", err)
+	}
+}
+
+func contains(xs []int64, x int64) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -575,6 +575,51 @@ func TestHandleTorrentRemoveBatchFetchesTransfersOnce(t *testing.T) {
 	}
 }
 
+func TestHandleTorrentRemovePartialBatchSkipsUnknown(t *testing.T) {
+	// A batch mixing a known hash with one that isn't in the transfer list must
+	// purge only the known transfer, skip the missing one, and still report
+	// success — all from a single GetTransfers fetch.
+	client := &fakePutioClient{
+		transfers: []*putio.Transfer{
+			{ID: 100, Hash: "known", FileID: 9, Name: "x"},
+		},
+	}
+	dl := newFakeDownloadService()
+	dl.SetCategory("known", "tv")
+	srv := newTestServer(t, client, dl)
+
+	req := rpcRequest(t, "torrent-remove", map[string]interface{}{
+		"ids":               []string{"known", "missing"},
+		"delete-local-data": false,
+	})
+	w := httptest.NewRecorder()
+	srv.handleRPC(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	resp := decodeRPCResponse(t, w.Body.Bytes())
+	if resp.Result != "success" {
+		t.Errorf("result = %q, want success", resp.Result)
+	}
+	dl.mu.Lock()
+	purgeCalls := append([]int64(nil), dl.purgeTransferCalls...)
+	dl.mu.Unlock()
+	if len(purgeCalls) != 1 || purgeCalls[0] != 100 {
+		t.Errorf("PurgeTransfer calls = %v, want [100] (missing hash skipped)", purgeCalls)
+	}
+	client.mu.Lock()
+	calls := client.getTransfersCalls
+	client.mu.Unlock()
+	if calls != 1 {
+		t.Errorf("GetTransfers calls = %d, want 1 for the whole batch", calls)
+	}
+	// The known transfer's category mapping is cleaned up.
+	if got := dl.GetCategory("known"); got != "" {
+		t.Errorf("category for known after remove = %q, want empty", got)
+	}
+}
+
 func TestHandleTorrentRemoveSurfacesListError(t *testing.T) {
 	// When the transfer-list fetch fails, the handler must report an error
 	// rather than silently returning success with nothing removed.

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -39,6 +39,7 @@ type fakePutioClient struct {
 	uploadFileCalls     []uploadFileCall
 	addTransferCalls    []addTransferCall
 	deleteFileCalls     []int64
+	getTransfersCalls   int
 	deleteTransferCalls []int64
 
 	transfers []*putio.Transfer
@@ -83,6 +84,7 @@ func (f *fakePutioClient) GetAccountInfo(ctx context.Context) (*putio.AccountInf
 func (f *fakePutioClient) GetTransfers(ctx context.Context) ([]*putio.Transfer, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.getTransfersCalls++
 	return f.transfers, f.getTransfersErr
 }
 
@@ -532,6 +534,70 @@ func TestHandleTorrentRemoveDelegatesToPurgeTransfer(t *testing.T) {
 	// Category mapping should be cleaned up via dlService.RemoveCategory.
 	if got := dl.GetCategory("abc"); got != "" {
 		t.Errorf("category for abc after remove = %q, want empty", got)
+	}
+}
+
+func TestHandleTorrentRemoveBatchFetchesTransfersOnce(t *testing.T) {
+	// torrent-remove accepts an array of ids. Resolving each hash used to
+	// trigger a full GetTransfers round trip per id (an N+1 against put.io);
+	// the list is now fetched once and indexed by hash. Three ids => one call.
+	client := &fakePutioClient{
+		transfers: []*putio.Transfer{
+			{ID: 100, Hash: "a", FileID: 901, Name: "one"},
+			{ID: 200, Hash: "b", FileID: 902, Name: "two"},
+			{ID: 300, Hash: "c", FileID: 903, Name: "three"},
+		},
+	}
+	dl := newFakeDownloadService()
+	srv := newTestServer(t, client, dl)
+
+	req := rpcRequest(t, "torrent-remove", map[string]interface{}{
+		"ids":               []string{"a", "b", "c"},
+		"delete-local-data": false,
+	})
+	w := httptest.NewRecorder()
+	srv.handleRPC(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	client.mu.Lock()
+	calls := client.getTransfersCalls
+	client.mu.Unlock()
+	if calls != 1 {
+		t.Errorf("GetTransfers calls = %d, want 1 (one fetch for the whole batch)", calls)
+	}
+	dl.mu.Lock()
+	purgeCalls := append([]int64(nil), dl.purgeTransferCalls...)
+	dl.mu.Unlock()
+	if len(purgeCalls) != 3 {
+		t.Errorf("PurgeTransfer calls = %v, want 3 purges", purgeCalls)
+	}
+}
+
+func TestHandleTorrentRemoveSurfacesListError(t *testing.T) {
+	// When the transfer-list fetch fails, the handler must report an error
+	// rather than silently returning success with nothing removed.
+	client := &fakePutioClient{getTransfersErr: errors.New("boom")}
+	dl := newFakeDownloadService()
+	srv := newTestServer(t, client, dl)
+
+	req := rpcRequest(t, "torrent-remove", map[string]interface{}{
+		"ids":               []string{"a"},
+		"delete-local-data": false,
+	})
+	w := httptest.NewRecorder()
+	srv.handleRPC(w, req)
+
+	resp := decodeRPCResponse(t, w.Body.Bytes())
+	if resp.Result == "success" {
+		t.Errorf("result = %q, want a non-success error result", resp.Result)
+	}
+	dl.mu.Lock()
+	purgeCalls := len(dl.purgeTransferCalls)
+	dl.mu.Unlock()
+	if purgeCalls != 0 {
+		t.Errorf("PurgeTransfer calls = %d, want 0 when list fetch fails", purgeCalls)
 	}
 }
 

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -38,9 +38,11 @@ func (s *Server) sendResponse(w http.ResponseWriter, tag interface{}, result int
 		Arguments: result,
 	}
 
-	// Log the response for debugging
-	respBytes, _ := json.Marshal(resp)
-	log.Debug("server").Msgf("Sending response: %s", string(respBytes))
+	// Log the response for debugging. Pass resp as a deferred field rather than
+	// pre-marshaling: zerolog only serializes it when debug is actually enabled,
+	// so the common case (info level, three *arrs polling torrent-get every few
+	// seconds) no longer marshals the full torrent list twice per response.
+	log.Debug("server").Interface("response", resp).Msg("Sending response")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Transmission-Session-Id", "123") // Ensure session ID is always sent

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -48,10 +49,14 @@ type DownloadService interface {
 
 // Server handles transmission-rpc requests
 type Server struct {
-	cfg          *config.Config
-	client       PutioClient
-	srv          *http.Server
-	quotaTicker  *time.Ticker
+	cfg    *config.Config
+	client PutioClient
+
+	// srvMu guards srv, which Start() writes (from its own goroutine in main.go)
+	// and Stop() reads concurrently.
+	srvMu       sync.Mutex
+	srv         *http.Server
+	quotaTicker *time.Ticker
 	stopChan     chan struct{}
 	dlService    DownloadService
 	quotaWarning atomic.Bool // tracks if we've already warned about quota
@@ -144,10 +149,13 @@ func (s *Server) Start() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/transmission/rpc", s.handleRPC)
 
+	s.srvMu.Lock()
 	s.srv = &http.Server{
 		Addr:    s.cfg.ListenAddr,
 		Handler: mux,
 	}
+	srv := s.srv
+	s.srvMu.Unlock()
 
 	// Get and log account info. Goes through the cache so the immediately
 	// following checkDiskQuota (and the first torrent-add) reuse this fetch
@@ -186,10 +194,19 @@ func (s *Server) Start() error {
 	}()
 
 	log.Info("server").Str("addr", s.cfg.ListenAddr).Msg("Starting transmission-rpc server")
-	return s.srv.ListenAndServe()
+	// A clean Stop() (Shutdown/Close) makes ListenAndServe return
+	// http.ErrServerClosed. Normalize it to nil so the caller in main.go — which
+	// log.Fatals on any non-nil error — doesn't kill the process (exit 1, scary
+	// "Server error" log) on every normal SIGTERM shutdown. Mirrors the
+	// dashboard's Start(). Only a real bind/serve failure surfaces as an error.
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
 }
 
-// Stop gracefully shuts down the server
+// Stop gracefully shuts down the server, draining in-flight RPC requests before
+// closing. Falls back to a hard Close if the drain doesn't finish in time.
 func (s *Server) Stop() error {
 	s.quotaTicker.Stop()
 	close(s.stopChan)
@@ -197,8 +214,18 @@ func (s *Server) Stop() error {
 	// Stop the download service
 	s.dlService.Stop()
 
-	if s.srv != nil {
-		return s.srv.Close()
+	s.srvMu.Lock()
+	srv := s.srv
+	s.srvMu.Unlock()
+	if srv == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		// Drain timed out (or failed) — force the connections closed so shutdown
+		// doesn't hang. ListenAndServe still returns ErrServerClosed either way.
+		return srv.Close()
 	}
 	return nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// TestServerStartReturnsNilOnCleanStop guards the regression where Start
+// returned http.ErrServerClosed on a normal Stop. main.go log.Fatals on any
+// non-nil Start error, so leaking ErrServerClosed turned every clean SIGTERM
+// shutdown into a fatal exit(1). A clean Stop must make Start return nil.
+func TestServerStartReturnsNilOnCleanStop(t *testing.T) {
+	// Reserve a free localhost port, then hand it to the server.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	srv := newTestServer(t, &fakePutioClient{}, newFakeDownloadService())
+	srv.cfg.ListenAddr = addr
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start() }()
+
+	// Wait until the listener is actually accepting before stopping, so we
+	// exercise the ListenAndServe → ErrServerClosed path rather than a pre-bind
+	// race.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if derr == nil {
+			_ = c.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server did not start listening on %s", addr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := srv.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("Start returned %v, want nil after a clean Stop", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after Stop")
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,7 +4,31 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/doodla/go-putio"
 )
+
+// TestCheckDiskQuotaZeroSize guards against the division-by-zero edge case:
+// an account reporting Disk.Size == 0 (unlimited plan, or a zero-value Disk
+// from an API hiccup) must not produce a NaN/+Inf percentage and a spurious
+// "over quota" result.
+func TestCheckDiskQuotaZeroSize(t *testing.T) {
+	acc := &putio.AccountInfo{Username: "u"}
+	acc.Disk.Size = 0
+	acc.Disk.Used = 1234 // Used>0, Size==0 would be +Inf% without the guard
+	srv := newTestServer(t, &fakePutioClient{accountInfo: acc}, newFakeDownloadService())
+
+	over, err := srv.checkDiskQuota()
+	if err != nil {
+		t.Fatalf("checkDiskQuota: %v", err)
+	}
+	if over {
+		t.Error("over quota = true for zero-size disk, want false")
+	}
+	if srv.quotaWarning.Load() {
+		t.Error("quotaWarning set for zero-size disk, want unset")
+	}
+}
 
 // TestServerStartReturnsNilOnCleanStop guards the regression where Start
 // returned http.ErrServerClosed on a normal Stop. main.go log.Fatals on any

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -30,6 +30,50 @@ func TestCheckDiskQuotaZeroSize(t *testing.T) {
 	}
 }
 
+// TestCheckDiskQuotaLatchAndRecovery covers the warning latch: usage >= 95%
+// reports over-quota and sets the one-shot warning; when usage later drops the
+// latch resets so a future spike can warn again.
+func TestCheckDiskQuotaLatchAndRecovery(t *testing.T) {
+	acc := &putio.AccountInfo{Username: "u"}
+	acc.Disk.Size = 1000
+	acc.Disk.Used = 960 // 96% — at/over the 95% threshold
+	fake := &fakePutioClient{accountInfo: acc}
+	srv := newTestServer(t, fake, newFakeDownloadService())
+
+	// Pin a controllable clock so we can expire the 60s account cache between
+	// the over-quota and recovery observations.
+	base := time.Now()
+	srv.now = func() time.Time { return base }
+
+	over, err := srv.checkDiskQuota()
+	if err != nil {
+		t.Fatalf("checkDiskQuota: %v", err)
+	}
+	if !over {
+		t.Error("over = false at 96% usage, want true")
+	}
+	if !srv.quotaWarning.Load() {
+		t.Error("quotaWarning latch not set after crossing threshold")
+	}
+
+	// Usage drops; expire the cache so the new figure is fetched.
+	fake.mu.Lock()
+	fake.accountInfo.Disk.Used = 500 // 50%
+	fake.mu.Unlock()
+	srv.now = func() time.Time { return base.Add(2 * time.Minute) }
+
+	over, err = srv.checkDiskQuota()
+	if err != nil {
+		t.Fatalf("checkDiskQuota (recovery): %v", err)
+	}
+	if over {
+		t.Error("over = true at 50% usage, want false")
+	}
+	if srv.quotaWarning.Load() {
+		t.Error("quotaWarning latch not reset after usage dropped")
+	}
+}
+
 // TestServerStartReturnsNilOnCleanStop guards the regression where Start
 // returned http.ErrServerClosed on a normal Stop. main.go log.Fatals on any
 // non-nil Start error, so leaking ErrServerClosed turned every clean SIGTERM

--- a/internal/server/torrent.go
+++ b/internal/server/torrent.go
@@ -51,18 +51,22 @@ func extractCategory(targetDir, downloadDir string) string {
 	return rel
 }
 
-// findTransferByHash finds a transfer by its hash string
-func (s *Server) findTransferByHash(ctx context.Context, hash string) (*putio.Transfer, error) {
+// transfersByHash fetches the transfer list once and indexes it by hash.
+// handleTorrentRemove uses this instead of a per-id lookup: the Transmission
+// RPC ids field is an array (*arr can batch removals), and a lookup that
+// fetched the full list per hash was an N+1 against the put.io API. On a
+// hash collision the last transfer wins — put.io hashes are unique in
+// practice, so this is only a theoretical tie-break.
+func (s *Server) transfersByHash(ctx context.Context) (map[string]*putio.Transfer, error) {
 	transfers, err := s.client.GetTransfers(ctx)
 	if err != nil {
 		return nil, err
 	}
+	byHash := make(map[string]*putio.Transfer, len(transfers))
 	for _, t := range transfers {
-		if t.Hash == hash {
-			return t, nil
-		}
+		byHash[t.Hash] = t
 	}
-	return nil, fmt.Errorf("transfer not found with hash: %s", hash)
+	return byHash, nil
 }
 
 // handleTorrentAdd processes torrent-add requests
@@ -304,14 +308,25 @@ func (s *Server) handleTorrentRemove(ctx context.Context, args json.RawMessage) 
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
 
+	// Resolve every requested hash from a single transfer-list fetch. If the
+	// fetch itself fails we surface the error rather than reporting success
+	// with nothing removed — *arr can then retry the removal.
+	byHash, err := s.transfersByHash(ctx)
+	if err != nil {
+		log.Error("rpc").
+			Str("operation", "torrent-remove").
+			Err(err).
+			Msg("Failed to list transfers")
+		return nil, fmt.Errorf("failed to list transfers: %w", err)
+	}
+
 	for _, hash := range params.IDs {
-		transfer, err := s.findTransferByHash(ctx, hash)
-		if err != nil {
+		transfer, ok := byHash[hash]
+		if !ok {
 			log.Error("rpc").
 				Str("operation", "torrent-remove").
 				Str("hash", hash).
-				Err(err).
-				Msg("Failed to find transfer")
+				Msg("Failed to find transfer with hash")
 			continue
 		}
 

--- a/internal/server/utils.go
+++ b/internal/server/utils.go
@@ -14,6 +14,14 @@ func (s *Server) checkDiskQuota() (bool, error) {
 		return false, fmt.Errorf("failed to check disk quota: %w", err)
 	}
 
+	// Guard against Disk.Size == 0 (unlimited plans report 0, and a zero-value
+	// Disk can come back from an API hiccup). Float division by zero would yield
+	// NaN/+Inf — a Used>0 case would then log a bogus "over quota (+Inf% used)"
+	// warning. With no known size we can't be over quota, so report false.
+	if account.Disk.Size <= 0 {
+		return false, nil
+	}
+
 	// Calculate usage percentage
 	usagePercent := float64(account.Disk.Used) / float64(account.Disk.Size) * 100
 


### PR DESCRIPTION
A pass of self-contained bug fixes, robustness hardening, and test backfill across the daemon. Every change is behavior-preserving on the happy path, covered by tests, and green under `go test -race ./...`. No public/RPC contract changes except the one intentional one noted below.

## Bug fixes

- **`server`: don't fatal on clean shutdown; drain gracefully.** `Start()` returned `http.ErrServerClosed` verbatim, and main.go `log.Fatal`s on any non-nil `Start` error — so **every normal SIGTERM exited non-zero with a fatal "Server error" log**, racing the orderly shutdown of the download manager and dashboard. Normalized `ErrServerClosed` → nil (matching the dashboard), switched `Stop()` to `Shutdown(ctx)` (5s) with a `Close` fallback, and guarded `srv` with a mutex (fixing a pre-existing `Start`/`Stop` data race the new lifecycle test surfaces under `-race`).
- **`download`: persist category state atomically.** `CategoryStore.save` used `os.WriteFile` (truncate-then-write); a crash/full-disk mid-write lost **all** hash→category mappings, sending downloads to the flat target dir. Now temp-file + atomic rename, serialized.
- **`config`: atomic + race-safe overrides writes.** Fixed shared fixed-name temp clobber (unique temp via `os.CreateTemp`) and the load-merge-write lost-update on concurrent dashboard PUTs (serialized with a mutex). Guard test verified to fail without the lock.
- **`download`: cancellable retry backoff.** The retry backoff slept even after the final attempt (wasted seconds per doomed file) and ignored shutdown (blocking `Stop()`). Now skips the final-attempt sleep and selects on `stopChan`.
- **`server`: guard `checkDiskQuota` against zero disk size.** A `Disk.Size == 0` account (unlimited plans / API hiccup) produced `NaN`/`+Inf` percent and a bogus "over quota (+Inf% used)" warning.
- **`download`: guard download-rate against zero elapsed.** `speedMBps` was computed outside the `elapsed > 0` guard and flowed into `SetLocalProgress` → dashboard/RPC `rateDownload`; unified to one guarded byte-rate.
- **`cli`: don't abort `get-token` on a transient poll error.** A single transient `http.Get` blip during the 5-minute device-code poll called `log.Fatal`; now logs and retries.

## Performance

- **`server`: fetch the transfer list once for batch `torrent-remove`.** `handleTorrentRemove` did a full `GetTransfers` round trip *per* hash (the RPC `ids` field is an array — an N+1). Now one fetch indexed by hash. **Intentional behavior change:** a list-fetch failure now surfaces as an RPC error instead of falsely reporting success with nothing removed, so *arr can retry.
- **`server`: don't marshal RPC responses when debug logging is off.** `sendResponse` marshaled the full response (incl. `torrent-get`'s whole list, polled every few seconds) on every call just for a debug string; now a deferred zerolog field.

## Refactor / cleanup (from `/code-review` + `/simplify`)

- **Extract `internal/atomicfile.WriteFile`** — a single tested atomic-write primitive replacing the temp+rename dance duplicated in `CategoryStore.save` and `config.WriteOverride`.

## Docs

- **`config`: sample config completeness.** `generate-config` was missing `dashboard`, `dashboard_addr`, and `transfer_check_interval` (and their `PLDR_*` env vars), making the dashboard undiscoverable from the sample; added them plus a drift test that every sample key maps to a `Config` field.

## Tests

Significant backfill of previously-untested logic:

- **End-to-end:** full RPC↔Manager lifecycle with a real `grab` HTTP download to disk (put.io COMPLETED → download → `torrent-get` 100% → `torrent-remove` purge), plus the `delete-local-data` variant; download-package e2e driving the real `grab` primitive (success, transient-503 retry, 404 fails-fast).
- **api client:** previously only rate-limit tests — added HTTP-layer coverage (via `BaseURL` injection against `httptest`) for `GetAllTransferFiles` (recursive walk + RelPath), `EnsureFolder` (find-or-create), `AddTransfer` (ERROR-status rejection), and `Authenticate` (empty-username rejection).
- **Edge cases:** quota over-limit latch/recovery, `torrent-remove` partial (found+missing) batches, atomic-write concurrency, `resolveOverridesPath` precedence, retry/backoff/cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY5kjyA2KBGYh9MnNviUoZ